### PR TITLE
Stateful urwasm

### DIFF
--- a/source/m3_code.c
+++ b/source/m3_code.c
@@ -20,7 +20,7 @@ IM3CodePage  NewCodePage  (u32 i_minNumLines)
     u32 pageSize = sizeof (M3CodePageHeader) + sizeof (code_t) * i_minNumLines;
 
     pageSize = (pageSize + (d_m3CodePageAlignSize-1)) & ~(d_m3CodePageAlignSize-1); // align
-    page = (IM3CodePage)m3_Malloc (pageSize);
+    page = (IM3CodePage)m3_MallocTransient (pageSize);
 
     if (page)
     {
@@ -29,7 +29,7 @@ IM3CodePage  NewCodePage  (u32 i_minNumLines)
 
 #if d_m3RecordBacktraces
         u32 pageSizeBt = sizeof (M3CodeMappingPage) + sizeof (M3CodeMapEntry) * page->info.numLines;
-        page->info.mapping = (M3CodeMappingPage *)m3_Malloc (pageSizeBt);
+        page->info.mapping = (M3CodeMappingPage *)m3_MallocTransient (pageSizeBt);
 
         if (page->info.mapping)
         {
@@ -38,7 +38,7 @@ IM3CodePage  NewCodePage  (u32 i_minNumLines)
         }
         else
         {
-            m3_Free (page);
+            m3_FreeTransient (page);
             return NULL;
         }
         page->info.mapping->basePC = GetPageStartPC(page);
@@ -61,9 +61,9 @@ void  FreeCodePages  (IM3CodePage * io_list)
 
         IM3CodePage next = page->info.next;
 #if d_m3RecordBacktraces
-        m3_Free (page->info.mapping);
+        m3_FreeTransient (page->info.mapping);
 #endif // d_m3RecordBacktraces
-        m3_Free (page);
+        m3_FreeTransient (page);
         page = next;
     }
 

--- a/source/m3_code.c
+++ b/source/m3_code.c
@@ -28,6 +28,7 @@ IM3CodePage  NewCodePage  (u32 i_minNumLines)
         page->info.numLines = (pageSize - sizeof (M3CodePageHeader)) / sizeof (code_t);
 
 #if d_m3RecordBacktraces
+# error "no backtraces"
         u32 pageSizeBt = sizeof (M3CodeMappingPage) + sizeof (M3CodeMapEntry) * page->info.numLines;
         page->info.mapping = (M3CodeMappingPage *)m3_MallocTransient (pageSizeBt);
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1365,6 +1365,16 @@ _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
     u32 num_loops = 0;
     if (o->block.depth > 0 && depth > 0)
     {
+        // u32 blocks_to_count = target;
+        // u32 num_blocks = o->block.depth;
+        // while (blocks_to_count--)
+        // {
+        //     num_blocks--;
+        //     if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
+        //     {
+        //         num_loops++;
+        //     }
+        // }
         u32 blocks_to_count = depth;
         u32 block_idx = o->block.depth - 1;
         if ( (block_idx & 31) < blocks_to_count )  // blockIsLoop chunk from LSB to some bit
@@ -1388,11 +1398,12 @@ _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
         }
 
 
-        if (blocks_to_count)    // blockIsLoop chunk from MSB to some bit
+        if (blocks_to_count)    // blockIsLoop partial chunk
         {
             u32 bits = o->blockIsLoop[block_idx >> 5];
+            u32 low_bits_mask_out = 1 + (block_idx & 31) - blocks_to_count;
             bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
-                ^ (((u32)1 << (1 + (block_idx & 31) - blocks_to_count)) - 1);
+                ^ (((u32)1 << low_bits_mask_out) - 1);
             
             num_loops += __builtin_popcount(bits);
         }
@@ -1560,16 +1571,45 @@ _       (ReadLEB_u32 (& target, & o->wasm, o->wasmEnd));
         u32 num_loops = 0;
         if (o->block.depth > 0 && target > 0)
         {
+            // u32 blocks_to_count = target;
+            // u32 num_blocks = o->block.depth;
+            // while (blocks_to_count--)
+            // {
+            //     num_blocks--;
+            //     if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
+            //     {
+            //         num_loops++;
+            //     }
+            // }
             u32 blocks_to_count = target;
-            u32 num_blocks = o->block.depth;
-            /* TODO optimize with masking and popcnt */
-            while (blocks_to_count--)
+            u32 block_idx = o->block.depth - 1;
+            if ( (block_idx & 31) < blocks_to_count )  // blockIsLoop chunk from LSB to some bit
             {
-                num_blocks--;
-                if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
                 {
-                    num_loops++;
+                    u32 bits = o->blockIsLoop[block_idx >> 5]
+                        & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
+                    
+                    num_loops += __builtin_popcount(bits);
+                    blocks_to_count -= (block_idx & 31) + 1;
+                    block_idx = (block_idx & ~((u32)31)) - 1;
                 }
+
+                while (blocks_to_count >= 32)   // full blockIsLoop chunks
+                {
+                    u32 bits = o->blockIsLoop[block_idx >> 5];
+                    num_loops += __builtin_popcount(bits);
+                    blocks_to_count -= 32;
+                    block_idx -= 32;
+                }
+            }
+            if (blocks_to_count)    // blockIsLoop partial chunk
+            {
+                u32 bits = o->blockIsLoop[block_idx >> 5];
+                u32 low_bits_mask_out = 1 + (block_idx & 31) - blocks_to_count;
+                bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
+                    ^ (((u32)1 << low_bits_mask_out) - 1);
+                
+                num_loops += __builtin_popcount(bits);
             }
         }
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1746,10 +1746,11 @@ _try {
     u32 typeIndex;
 _   (ReadLEB_u32 (& typeIndex, & o->wasm, o->wasmEnd));
 
-    i8 reserved;
-_   (ReadLEB_i7 (& reserved, & o->wasm, o->wasmEnd));
+    u32 table_idx;
+_   (ReadLEB_u32 (& table_idx, & o->wasm, o->wasmEnd));
 
     _throwif ("function call type index out of range", typeIndex >= o->module->numFuncTypes);
+    _throwif ("non-zero table index not supported", table_idx > 0);
 
     if (IsStackTopInRegister (o))
 _       (PreserveRegisterIfOccupied (o, c_m3Type_i32));

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1366,15 +1366,28 @@ _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
     if (o->block.depth > 0 && depth > 0)
     {
         u32 blocks_to_count = depth;
-        u32 num_blocks = o->block.depth;
-        /* TODO optimize with masking and popcnt */
-        while (blocks_to_count--)
+        u32 block_idx = o->block.depth - 1;
+        while ( (block_idx & 31) < blocks_to_count )
         {
-            num_blocks--;
-            if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
-            {
-                num_loops++;
-            }
+            u32 bits = o->blockIsLoop[block_idx >> 5]
+                & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
+            
+            num_loops += __builtin_popcount(bits);
+            
+            blocks_to_count -= (block_idx & 31);
+            blocks_to_count--;
+            
+            block_idx &= ~((u32)31);
+            block_idx--;
+        }
+
+        if (blocks_to_count)
+        {
+            u32 bits = o->blockIsLoop[block_idx >> 5];
+            bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
+                ^ ((u32)1 << (1 + (block_idx & 31) - blocks_to_count)) - 1;
+            
+            num_loops += __builtin_popcount(bits);
         }
     }
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1385,7 +1385,7 @@ _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
         {
             u32 bits = o->blockIsLoop[block_idx >> 5];
             bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
-                ^ ((u32)1 << (1 + (block_idx & 31) - blocks_to_count)) - 1;
+                ^ (((u32)1 << (1 + (block_idx & 31) - blocks_to_count)) - 1);
             
             num_loops += __builtin_popcount(bits);
         }

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1138,29 +1138,6 @@ M3Result  Compile_Return  (IM3Compilation o, m3opcode_t i_opcode)
 
     if (not IsStackPolymorphic (o))
     {
-        if (o->block.depth > 0)
-        {
-            i32 num_blocks = o->block.depth;
-            u32 num_loops = 0;
-            u32 i = 0;
-            while (num_blocks >= 32)
-            {
-                u32 bit_array = o->blockIsLoop[i];
-                num_loops += __builtin_popcount(bit_array);
-                num_blocks -= 32;
-                i++;
-            }
-            if (num_blocks > 0)
-            {
-                u32 bit_array = o->blockIsLoop[i];
-                u32 mask = ((u32)1 << num_blocks) - 1;
-                num_loops += __builtin_popcount(bit_array & mask);
-            }
-
-            _( EmitOp(o, op_SuspendPopLoop) );
-            EmitConstant32 (o, num_loops);
-        }
-        
         IM3CompilationScope functionScope;
 _       (GetBlockScope (o, & functionScope, o->block.depth));
 
@@ -1211,11 +1188,6 @@ _               (ReturnValues (o, & o->block, false));
 
 _           (EmitOp (o, op_Return));
         }
-    }
-    else if (o->block.opcode == c_waOp_loop)
-    {
-        _( EmitOp(o, op_SuspendPopLoop) );
-        EmitConstant32 (o, 1);
     }
 
     _catch: return result;
@@ -1362,53 +1334,6 @@ M3Result  Compile_Branch  (IM3Compilation o, m3opcode_t i_opcode)
     u32 depth;
 _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
 
-    u32 num_loops = 0;
-    if (o->block.depth > 0 && depth > 0)
-    {
-        // u32 blocks_to_count = target;
-        // u32 num_blocks = o->block.depth;
-        // while (blocks_to_count--)
-        // {
-        //     num_blocks--;
-        //     if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
-        //     {
-        //         num_loops++;
-        //     }
-        // }
-        u32 blocks_to_count = depth;
-        u32 block_idx = o->block.depth - 1;
-        if ( (block_idx & 31) < blocks_to_count )  // blockIsLoop chunk from LSB to some bit
-        {
-            {
-                u32 bits = o->blockIsLoop[block_idx >> 5]
-                    & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
-                
-                num_loops += __builtin_popcount(bits);
-                blocks_to_count -= (block_idx & 31) + 1;
-                block_idx = (block_idx & ~((u32)31)) - 1;
-            }
-            
-            while (blocks_to_count >= 32)   // full blockIsLoop chunks
-            {
-                u32 bits = o->blockIsLoop[block_idx >> 5];
-                num_loops += __builtin_popcount(bits);
-                blocks_to_count -= 32;
-                block_idx -= 32;
-            }
-        }
-
-
-        if (blocks_to_count)    // blockIsLoop partial chunk
-        {
-            u32 bits = o->blockIsLoop[block_idx >> 5];
-            u32 low_bits_mask_out = 1 + (block_idx & 31) - blocks_to_count;
-            bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
-                ^ (((u32)1 << low_bits_mask_out) - 1);
-            
-            num_loops += __builtin_popcount(bits);
-        }
-    }
-
     IM3CompilationScope scope;
 _   (GetBlockScope (o, & scope, depth));
 
@@ -1428,11 +1353,6 @@ _               (EmitSlotNumOfStackTopAndPop (o));
 
 _               (ResolveBlockResults (o, scope, /* isBranch: */ true));
 
-                if (num_loops)
-                {
-                    _( EmitOp(o, op_SuspendPopLoop) );
-                    EmitConstant32 (o, num_loops);
-                }
 _               (EmitOp (o, op_ContinueLoop));
                 EmitPointer (o, scope->pc);
 
@@ -1446,18 +1366,12 @@ _               (PopType (o, c_m3Type_i32));
 
 _               (EmitOp (o, op_ContinueLoopIf));
                 EmitPointer (o, scope->pc);
-                EmitConstant32 (o, num_loops);
             }
 
 //          dump_type_stack(o);
         }
         else // is c_waOp_branch
         {
-            if (num_loops)
-            {
-                _( EmitOp(o, op_SuspendPopLoop) );
-                EmitConstant32 (o, num_loops);
-            }
     _       (EmitOp (o, op_ContinueLoop));
             EmitPointer (o, scope->pc);
             o->block.isPolymorphic = true;
@@ -1487,7 +1401,6 @@ _               (EmitOp (o, op_ContinueLoopIf));
                 IM3Operation op = IsStackTopInRegister (o) ? op_BranchIf_r : op_BranchIf_s;
 
     _           (EmitOp (o, op));
-                EmitConstant32 (o, num_loops);
     _           (EmitSlotNumOfStackTopAndPop (o)); // condition
 
                 EmitPatchingBranchPointer (o, scope);
@@ -1507,20 +1420,7 @@ _               (EmitOp (o, op_Return));
             else
             {
 _               (ResolveBlockResults (o, scope, true));
-                if (num_loops)
-                {
-                    _( EmitOp(o, op_SuspendPopLoop) );
-                    EmitConstant32 (o, num_loops);
-                }
 _               (EmitPatchingBranch (o, scope));
-            }
-        }
-        else
-        {
-            if (num_loops)
-            {
-                _( EmitOp(o, op_SuspendPopLoop) );
-                EmitConstant32 (o, num_loops);
             }
         }
 
@@ -1568,51 +1468,6 @@ _   (EmitOp (o, op_BranchTable));
         u32 target;
 _       (ReadLEB_u32 (& target, & o->wasm, o->wasmEnd));
 
-        u32 num_loops = 0;
-        if (o->block.depth > 0 && target > 0)
-        {
-            // u32 blocks_to_count = target;
-            // u32 num_blocks = o->block.depth;
-            // while (blocks_to_count--)
-            // {
-            //     num_blocks--;
-            //     if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
-            //     {
-            //         num_loops++;
-            //     }
-            // }
-            u32 blocks_to_count = target;
-            u32 block_idx = o->block.depth - 1;
-            if ( (block_idx & 31) < blocks_to_count )  // blockIsLoop chunk from LSB to some bit
-            {
-                {
-                    u32 bits = o->blockIsLoop[block_idx >> 5]
-                        & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
-                    
-                    num_loops += __builtin_popcount(bits);
-                    blocks_to_count -= (block_idx & 31) + 1;
-                    block_idx = (block_idx & ~((u32)31)) - 1;
-                }
-
-                while (blocks_to_count >= 32)   // full blockIsLoop chunks
-                {
-                    u32 bits = o->blockIsLoop[block_idx >> 5];
-                    num_loops += __builtin_popcount(bits);
-                    blocks_to_count -= 32;
-                    block_idx -= 32;
-                }
-            }
-            if (blocks_to_count)    // blockIsLoop partial chunk
-            {
-                u32 bits = o->blockIsLoop[block_idx >> 5];
-                u32 low_bits_mask_out = 1 + (block_idx & 31) - blocks_to_count;
-                bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)
-                    ^ (((u32)1 << low_bits_mask_out) - 1);
-                
-                num_loops += __builtin_popcount(bits);
-            }
-        }
-
         IM3CompilationScope scope;
 _       (GetBlockScope (o, & scope, target));
 
@@ -1628,11 +1483,6 @@ _       (AcquireCompilationCodePage (o, & continueOpPage));
         if (scope->opcode == c_waOp_loop)
         {
 _           (ResolveBlockResults (o, scope, true));
-            if (num_loops)
-            {
-                _( EmitOp(o, op_SuspendPopLoop) );
-                EmitConstant32 (o, num_loops);
-            }
 _           (EmitOp (o, op_ContinueLoop));
             EmitPointer (o, scope->pc);
         }
@@ -1650,21 +1500,7 @@ _                   (EmitOp (o, op_Return));
                 {
 _                   (ResolveBlockResults (o, scope, true));
 
-                    if (num_loops)
-                    {
-                        _( EmitOp(o, op_SuspendPopLoop) );
-                        EmitConstant32 (o, num_loops);
-                    }
-
 _                   (EmitPatchingBranch (o, scope));
-                }
-            }
-            else
-            {
-                if (num_loops)
-                {
-                    _( EmitOp(o, op_SuspendPopLoop) );
-                    EmitConstant32 (o, num_loops);
                 }
             }
         }
@@ -2722,29 +2558,6 @@ M3Result  CompileBlock  (IM3Compilation o, IM3FuncType i_blockType, m3opcode_t i
     block->depth            ++;
     block->opcode           = i_blockOpcode;
 
-    if (block->depth >= d_m3MaxSaneFrameDepth)
-    {
-        return "too many frames";
-    }
-
-    if (i_blockOpcode == c_waOp_loop)
-    { 
-        o->blockIsLoop[(block->depth - 1) >> 5]
-            |= (1U << ((block->depth - 1) & 31));
-    }
-    else if (
-        i_blockOpcode == c_waOp_block
-        || i_blockOpcode == c_waOp_if
-        || i_blockOpcode == c_waOp_else
-    )
-    {
-        o->blockIsLoop[(block->depth - 1) >> 5]
-            &= ~((u32)1U << ((block->depth - 1) & 31));
-    }
-    else
-    {
-        return "weird block opcode";
-    }
 
     /*
      The block stack frame is a little strange but for good reasons.  Because blocks need to be restarted to

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1143,7 +1143,7 @@ M3Result  Compile_Return  (IM3Compilation o, m3opcode_t i_opcode)
             i32 num_blocks = o->block.depth;
             u32 num_loops = 0;
             u32 i = 0;
-            while (num_blocks > 32)
+            while (num_blocks >= 32)
             {
                 u32 bit_array = o->blockIsLoop[i];
                 num_loops += __builtin_popcount(bit_array);
@@ -1153,7 +1153,7 @@ M3Result  Compile_Return  (IM3Compilation o, m3opcode_t i_opcode)
             if (num_blocks > 0)
             {
                 u32 bit_array = o->blockIsLoop[i];
-                u32 mask = (1U << num_blocks) - 1;
+                u32 mask = ((u32)1 << num_blocks) - 1;
                 num_loops += __builtin_popcount(bit_array & mask);
             }
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1367,21 +1367,28 @@ _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
     {
         u32 blocks_to_count = depth;
         u32 block_idx = o->block.depth - 1;
-        while ( (block_idx & 31) < blocks_to_count )
+        if ( (block_idx & 31) < blocks_to_count )  // blockIsLoop chunk from LSB to some bit
         {
-            u32 bits = o->blockIsLoop[block_idx >> 5]
-                & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
+            {
+                u32 bits = o->blockIsLoop[block_idx >> 5]
+                    & (u32)(((u64)1 << (1 + (block_idx & 31))) - 1);
+                
+                num_loops += __builtin_popcount(bits);
+                blocks_to_count -= (block_idx & 31) + 1;
+                block_idx = (block_idx & ~((u32)31)) - 1;
+            }
             
-            num_loops += __builtin_popcount(bits);
-            
-            blocks_to_count -= (block_idx & 31);
-            blocks_to_count--;
-            
-            block_idx &= ~((u32)31);
-            block_idx--;
+            while (blocks_to_count >= 32)   // full blockIsLoop chunks
+            {
+                u32 bits = o->blockIsLoop[block_idx >> 5];
+                num_loops += __builtin_popcount(bits);
+                blocks_to_count -= 32;
+                block_idx -= 32;
+            }
         }
 
-        if (blocks_to_count)
+
+        if (blocks_to_count)    // blockIsLoop chunk from MSB to some bit
         {
             u32 bits = o->blockIsLoop[block_idx >> 5];
             bits &= (u32)(((u64)1 << (1 + (block_idx & 31))) - 1)

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -2950,7 +2950,7 @@ _   (CompileBlockStatements (o));
 
     if (numConstantSlots)
     {
-        io_function->constants = m3_CopyMem (o->constants, io_function->numConstantBytes);
+        io_function->constants = m3_CopyMemTransient (o->constants, io_function->numConstantBytes);
         _throwifnull(io_function->constants);
     }
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1138,6 +1138,29 @@ M3Result  Compile_Return  (IM3Compilation o, m3opcode_t i_opcode)
 
     if (not IsStackPolymorphic (o))
     {
+        if (o->block.depth > 0)
+        {
+            i32 num_blocks = o->block.depth;
+            u32 num_loops = 0;
+            u32 i = 0;
+            while (num_blocks > 32)
+            {
+                u32 bit_array = o->blockIsLoop[i];
+                num_loops += __builtin_popcount(bit_array);
+                num_blocks -= 32;
+                i++;
+            }
+            if (num_blocks > 0)
+            {
+                u32 bit_array = o->blockIsLoop[i];
+                u32 mask = (1U << num_blocks) - 1;
+                num_loops += __builtin_popcount(bit_array & mask);
+            }
+
+            _( EmitOp(o, op_SuspendPopLoop) );
+            EmitConstant32 (o, num_loops);
+        }
+        
         IM3CompilationScope functionScope;
 _       (GetBlockScope (o, & functionScope, o->block.depth));
 
@@ -1188,6 +1211,11 @@ _               (ReturnValues (o, & o->block, false));
 
 _           (EmitOp (o, op_Return));
         }
+    }
+    else if (o->block.opcode == c_waOp_loop)
+    {
+        _( EmitOp(o, op_SuspendPopLoop) );
+        EmitConstant32 (o, 1);
     }
 
     _catch: return result;
@@ -1334,6 +1362,22 @@ M3Result  Compile_Branch  (IM3Compilation o, m3opcode_t i_opcode)
     u32 depth;
 _   (ReadLEB_u32 (& depth, & o->wasm, o->wasmEnd));
 
+    u32 num_loops = 0;
+    if (o->block.depth > 0 && depth > 0)
+    {
+        u32 blocks_to_count = depth;
+        u32 num_blocks = o->block.depth;
+        /* TODO optimize with masking and popcnt */
+        while (blocks_to_count--)
+        {
+            num_blocks--;
+            if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
+            {
+                num_loops++;
+            }
+        }
+    }
+
     IM3CompilationScope scope;
 _   (GetBlockScope (o, & scope, depth));
 
@@ -1353,6 +1397,11 @@ _               (EmitSlotNumOfStackTopAndPop (o));
 
 _               (ResolveBlockResults (o, scope, /* isBranch: */ true));
 
+                if (num_loops)
+                {
+                    _( EmitOp(o, op_SuspendPopLoop) );
+                    EmitConstant32 (o, num_loops);
+                }
 _               (EmitOp (o, op_ContinueLoop));
                 EmitPointer (o, scope->pc);
 
@@ -1366,12 +1415,18 @@ _               (PopType (o, c_m3Type_i32));
 
 _               (EmitOp (o, op_ContinueLoopIf));
                 EmitPointer (o, scope->pc);
+                EmitConstant32 (o, num_loops);
             }
 
 //          dump_type_stack(o);
         }
         else // is c_waOp_branch
         {
+            if (num_loops)
+            {
+                _( EmitOp(o, op_SuspendPopLoop) );
+                EmitConstant32 (o, num_loops);
+            }
     _       (EmitOp (o, op_ContinueLoop));
             EmitPointer (o, scope->pc);
             o->block.isPolymorphic = true;
@@ -1401,6 +1456,7 @@ _               (EmitOp (o, op_ContinueLoopIf));
                 IM3Operation op = IsStackTopInRegister (o) ? op_BranchIf_r : op_BranchIf_s;
 
     _           (EmitOp (o, op));
+                EmitConstant32 (o, num_loops);
     _           (EmitSlotNumOfStackTopAndPop (o)); // condition
 
                 EmitPatchingBranchPointer (o, scope);
@@ -1412,13 +1468,28 @@ _               (EmitOp (o, op_ContinueLoopIf));
         {
             if (isReturn)
             {
+                //  num_loops == 0 here
+                //
 _               (ReturnValues (o, scope, true));
 _               (EmitOp (o, op_Return));
             }
             else
             {
 _               (ResolveBlockResults (o, scope, true));
+                if (num_loops)
+                {
+                    _( EmitOp(o, op_SuspendPopLoop) );
+                    EmitConstant32 (o, num_loops);
+                }
 _               (EmitPatchingBranch (o, scope));
+            }
+        }
+        else
+        {
+            if (num_loops)
+            {
+                _( EmitOp(o, op_SuspendPopLoop) );
+                EmitConstant32 (o, num_loops);
             }
         }
 
@@ -1466,6 +1537,22 @@ _   (EmitOp (o, op_BranchTable));
         u32 target;
 _       (ReadLEB_u32 (& target, & o->wasm, o->wasmEnd));
 
+        u32 num_loops = 0;
+        if (o->block.depth > 0 && target > 0)
+        {
+            u32 blocks_to_count = target;
+            u32 num_blocks = o->block.depth;
+            /* TODO optimize with masking and popcnt */
+            while (blocks_to_count--)
+            {
+                num_blocks--;
+                if (o->blockIsLoop[num_blocks >> 5] & (1U << (num_blocks & 31)))
+                {
+                    num_loops++;
+                }
+            }
+        }
+
         IM3CompilationScope scope;
 _       (GetBlockScope (o, & scope, target));
 
@@ -1481,7 +1568,11 @@ _       (AcquireCompilationCodePage (o, & continueOpPage));
         if (scope->opcode == c_waOp_loop)
         {
 _           (ResolveBlockResults (o, scope, true));
-
+            if (num_loops)
+            {
+                _( EmitOp(o, op_SuspendPopLoop) );
+                EmitConstant32 (o, num_loops);
+            }
 _           (EmitOp (o, op_ContinueLoop));
             EmitPointer (o, scope->pc);
         }
@@ -1499,7 +1590,21 @@ _                   (EmitOp (o, op_Return));
                 {
 _                   (ResolveBlockResults (o, scope, true));
 
+                    if (num_loops)
+                    {
+                        _( EmitOp(o, op_SuspendPopLoop) );
+                        EmitConstant32 (o, num_loops);
+                    }
+
 _                   (EmitPatchingBranch (o, scope));
+                }
+            }
+            else
+            {
+                if (num_loops)
+                {
+                    _( EmitOp(o, op_SuspendPopLoop) );
+                    EmitConstant32 (o, num_loops);
                 }
             }
         }
@@ -1568,7 +1673,7 @@ _       (Push (o, type, topSlot));
 
 M3Result  Compile_Call  (IM3Compilation o, m3opcode_t i_opcode)
 {
-    M3Result result;
+    M3Result result = m3Err_none;
 
 _try {
     u32 functionIndex;
@@ -2555,6 +2660,30 @@ M3Result  CompileBlock  (IM3Compilation o, IM3FuncType i_blockType, m3opcode_t i
     block->type             = i_blockType;
     block->depth            ++;
     block->opcode           = i_blockOpcode;
+
+    if (block->depth >= d_m3MaxSaneFrameDepth)
+    {
+        return "too many frames";
+    }
+
+    if (i_blockOpcode == c_waOp_loop)
+    { 
+        o->blockIsLoop[(block->depth - 1) >> 5]
+            |= (1U << ((block->depth - 1) & 31));
+    }
+    else if (
+        i_blockOpcode == c_waOp_block
+        || i_blockOpcode == c_waOp_if
+        || i_blockOpcode == c_waOp_else
+    )
+    {
+        o->blockIsLoop[(block->depth - 1) >> 5]
+            &= ~((u32)1U << ((block->depth - 1) & 31));
+    }
+    else
+    {
+        return "weird block opcode";
+    }
 
     /*
      The block stack frame is a little strange but for good reasons.  Because blocks need to be restarted to

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1412,8 +1412,6 @@ _               (EmitOp (o, op_ContinueLoopIf));
         {
             if (isReturn)
             {
-                //  num_loops == 0 here
-                //
 _               (ReturnValues (o, scope, true));
 _               (EmitOp (o, op_Return));
             }

--- a/source/m3_compile.h
+++ b/source/m3_compile.h
@@ -146,6 +146,8 @@ typedef struct
     u16                 regStackIndexPlusOne        [2];
 
     m3opcode_t          previousOpcode;
+
+    u32                 blockIsLoop[(d_m3MaxSaneFrameDepth + 31) >> 5];  // bit array of whether a block scope is a loop
 }
 M3Compilation;
 

--- a/source/m3_compile.h
+++ b/source/m3_compile.h
@@ -146,8 +146,6 @@ typedef struct
     u16                 regStackIndexPlusOne        [2];
 
     m3opcode_t          previousOpcode;
-
-    u32                 blockIsLoop[(d_m3MaxSaneFrameDepth + 31) >> 5];  // bit array of whether a block scope is a loop
 }
 M3Compilation;
 

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -118,9 +118,9 @@ M3AllocationFunctionStruct  m3_alloc_transient_funcs = {
 };
 
 M3Result m3_SetAllocators  (
-    void* (* calloc_fn)(size_t, size_t),
-    void (* free_fn)(void*),
-    void* (* realloc_fn)(void*, size_t)
+    void*   (*calloc_fn)    (size_t, size_t),
+    void    (*free_fn)      (void*),
+    void*   (*realloc_fn)   (void*, size_t)
     )
 {
     if ( (calloc_fn == NULL) || (free_fn == NULL) || (realloc_fn == NULL) ) {

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -262,9 +262,9 @@ void *  m3_ReallocMemory  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
 
 #endif
 
-void *  m3_CopyMem  (const void * i_from, size_t i_size)
+void *  m3_CopyMemTransient  (const void * i_from, size_t i_size)
 {
-    void * ptr = m3_Malloc(i_size);
+    void * ptr = m3_MallocTransient(i_size);
     if (ptr) {
         memcpy (ptr, i_from, i_size);
     }

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -117,6 +117,12 @@ M3AllocationFunctionStruct  m3_alloc_transient_funcs = {
     realloc
 };
 
+M3AllocationFunctionStruct  m3_alloc_memory_funcs = {
+    calloc,
+    free,
+    realloc
+};
+
 M3Result m3_SetAllocators  (
     void*   (*calloc_fn)    (size_t, size_t),
     void    (*free_fn)      (void*),
@@ -136,9 +142,9 @@ M3Result m3_SetAllocators  (
 // allocated buffers, e.g. a bump allocator
 //
 M3Result m3_SetTransientAllocators  (
-    void* (* calloc_fn)(size_t, size_t),
-    void (* free_fn)(void*),
-    void* (* realloc_fn)(void*, size_t)
+    void*   (*calloc_fn)    (size_t, size_t),
+    void    (*free_fn)      (void*),
+    void*   (*realloc_fn)   (void*, size_t)
     )
 {
     if ( (calloc_fn == NULL) || (free_fn == NULL) || (realloc_fn == NULL) ) {
@@ -147,6 +153,21 @@ M3Result m3_SetTransientAllocators  (
     m3_alloc_transient_funcs.calloc_fn = calloc_fn;
     m3_alloc_transient_funcs.free_fn = free_fn;
     m3_alloc_transient_funcs.realloc_fn = realloc_fn;
+    return m3Err_none;
+}
+
+M3Result m3_SetMemoryAllocators  (
+    void*   (*calloc_fn)    (size_t, size_t),
+    void    (*free_fn)      (void*),
+    void*   (*realloc_fn)   (void*, size_t)
+    )
+{
+    if ( (calloc_fn == NULL) || (free_fn == NULL) || (realloc_fn == NULL) ) {
+        return m3Err_SetAllocatorsFail;
+    }
+    m3_alloc_memory_funcs.calloc_fn = calloc_fn;
+    m3_alloc_memory_funcs.free_fn = free_fn;
+    m3_alloc_memory_funcs.realloc_fn = realloc_fn;
     return m3Err_none;
 }
 
@@ -201,6 +222,33 @@ void *  m3_ReallocTransient  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
     if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
 
     void * newPtr = m3_alloc_transient_funcs.realloc_fn (i_ptr, i_newSize);
+
+    if (LIKELY(newPtr))
+    {
+        if (i_newSize > i_oldSize) {
+            memset ((u8 *) newPtr + i_oldSize, 0x0, i_newSize - i_oldSize);
+        }
+        return newPtr;
+    }
+    return NULL;
+}
+
+void *  m3_MallocMemory  (size_t i_size)
+{
+    void * ptr = m3_alloc_memory_funcs.calloc_fn (i_size, 1);
+    return ptr;
+}
+
+void  m3_FreeMemoryImpl  (void * io_ptr)
+{
+    m3_alloc_memory_funcs.free_fn (io_ptr);
+}
+
+void *  m3_ReallocMemory  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
+{
+    if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+
+    void * newPtr = m3_alloc_memory_funcs.realloc_fn (i_ptr, i_newSize);
 
     if (LIKELY(newPtr))
     {

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -111,6 +111,12 @@ M3AllocationFunctionStruct  m3_alloc_funcs = {
     realloc
 };
 
+M3AllocationFunctionStruct  m3_alloc_transient_funcs = {
+    calloc,
+    free,
+    realloc
+};
+
 M3Result m3_SetAllocators  (
     void* (* calloc_fn)(size_t, size_t),
     void (* free_fn)(void*),
@@ -123,6 +129,24 @@ M3Result m3_SetAllocators  (
     m3_alloc_funcs.calloc_fn = calloc_fn;
     m3_alloc_funcs.free_fn = free_fn;
     m3_alloc_funcs.realloc_fn = realloc_fn;
+    return m3Err_none;
+}
+
+// MUST be deterministic in terms of relative address of
+// allocated buffers, e.g. a bump allocator
+//
+M3Result m3_SetTransientAllocators  (
+    void* (* calloc_fn)(size_t, size_t),
+    void (* free_fn)(void*),
+    void* (* realloc_fn)(void*, size_t)
+    )
+{
+    if ( (calloc_fn == NULL) || (free_fn == NULL) || (realloc_fn == NULL) ) {
+        return m3Err_SetAllocatorsFail;
+    }
+    m3_alloc_transient_funcs.calloc_fn = calloc_fn;
+    m3_alloc_transient_funcs.free_fn = free_fn;
+    m3_alloc_transient_funcs.realloc_fn = realloc_fn;
     return m3Err_none;
 }
 
@@ -146,6 +170,37 @@ void *  m3_Realloc  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
     if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
 
     void * newPtr = m3_alloc_funcs.realloc_fn (i_ptr, i_newSize);
+
+    if (LIKELY(newPtr))
+    {
+        if (i_newSize > i_oldSize) {
+            memset ((u8 *) newPtr + i_oldSize, 0x0, i_newSize - i_oldSize);
+        }
+        return newPtr;
+    }
+    return NULL;
+}
+
+void *  m3_MallocTransient  (size_t i_size)
+{
+    void * ptr = m3_alloc_transient_funcs.calloc_fn (i_size, 1);
+
+//    printf("== alloc %d => %p\n", (u32) i_size, ptr);
+
+    return ptr;
+}
+
+void  m3_FreeTransientImpl  (void * io_ptr)
+{
+//    if (io_ptr) printf("== free %p\n", io_ptr);
+    m3_alloc_transient_funcs.free_fn (io_ptr);
+}
+
+void *  m3_ReallocTransient  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
+{
+    if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+
+    void * newPtr = m3_alloc_transient_funcs.realloc_fn (i_ptr, i_newSize);
 
     if (LIKELY(newPtr))
     {

--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -235,7 +235,7 @@ void        m3_FreeTransientImpl    (void * i_ptr);
 void *      m3_MallocMemory         (size_t i_size);
 void *      m3_ReallocMemory        (void *i_ptr, size_t i_newSize, size_t i_oldSize);
 void        m3_FreeMemoryImpl       (void * i_ptr);
-void *      m3_CopyMem              (const void * i_from, size_t i_size);
+void *      m3_CopyMemTransient     (const void * i_from, size_t i_size);
 
 #define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_Malloc (sizeof (STRUCT))
 #define     m3_AllocArray(STRUCT, NUM)              (STRUCT *)m3_Malloc (sizeof (STRUCT) * (NUM))

--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -181,7 +181,7 @@ M3AllocationFunctionStruct;
 #define d_m3MaxSaneFunctionArgRetCount      1000    // still insane, but whatever
 #define d_m3MaxSaneLocalCount               10000   // function args and declared locals
 #define d_m3MaxSaneTypeStackSize            100000
-#define d_m3MaxSaneFrameDepth               1000
+#define d_m3MaxSaneFrameDepth               1024
 
 #define d_externalKind_function             0
 #define d_externalKind_table                1
@@ -229,13 +229,16 @@ void        m3_Abort                (const char* message);
 void *      m3_Malloc               (size_t i_size);
 void *      m3_Realloc              (void *i_ptr, size_t i_newSize, size_t i_oldSize);
 void        m3_FreeImpl             (void * i_ptr);
+void *      m3_MallocTransient      (size_t i_size);
+void *      m3_ReallocTransient     (void *i_ptr, size_t i_newSize, size_t i_oldSize);
+void        m3_FreeTransientImpl    (void * i_ptr);
 void *      m3_CopyMem              (const void * i_from, size_t i_size);
 
 #define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_Malloc (sizeof (STRUCT))
 #define     m3_AllocArray(STRUCT, NUM)              (STRUCT *)m3_Malloc (sizeof (STRUCT) * (NUM))
 #define     m3_ReallocArray(STRUCT, PTR, NEW, OLD)  (STRUCT *)m3_Realloc ((void *)(PTR), sizeof (STRUCT) * (NEW), sizeof (STRUCT) * (OLD))
 #define     m3_Free(P)                              do { m3_FreeImpl ((void*)(P)); (P) = NULL; } while(0)
-
+#define     m3_FreeTransient(P)                     do { m3_FreeTransientImpl ((void*)(P)); (P) = NULL; } while(0)
 M3Result    NormalizeType           (u8 * o_type, i8 i_convolutedWasmType);
 
 bool        IsIntType               (u8 i_wasmType);

--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -232,6 +232,9 @@ void        m3_FreeImpl             (void * i_ptr);
 void *      m3_MallocTransient      (size_t i_size);
 void *      m3_ReallocTransient     (void *i_ptr, size_t i_newSize, size_t i_oldSize);
 void        m3_FreeTransientImpl    (void * i_ptr);
+void *      m3_MallocMemory         (size_t i_size);
+void *      m3_ReallocMemory        (void *i_ptr, size_t i_newSize, size_t i_oldSize);
+void        m3_FreeMemoryImpl       (void * i_ptr);
 void *      m3_CopyMem              (const void * i_from, size_t i_size);
 
 #define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_Malloc (sizeof (STRUCT))
@@ -239,6 +242,7 @@ void *      m3_CopyMem              (const void * i_from, size_t i_size);
 #define     m3_ReallocArray(STRUCT, PTR, NEW, OLD)  (STRUCT *)m3_Realloc ((void *)(PTR), sizeof (STRUCT) * (NEW), sizeof (STRUCT) * (OLD))
 #define     m3_Free(P)                              do { m3_FreeImpl ((void*)(P)); (P) = NULL; } while(0)
 #define     m3_FreeTransient(P)                     do { m3_FreeTransientImpl ((void*)(P)); (P) = NULL; } while(0)
+#define     m3_FreeMemory(P)                        do { m3_FreeMemoryImpl ((void*)(P)); (P) = NULL; } while(0)
 M3Result    NormalizeType           (u8 * o_type, i8 i_convolutedWasmType);
 
 bool        IsIntType               (u8 i_wasmType);

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -910,28 +910,26 @@ M3Result  m3_Call  (IM3Function i_function, uint32_t i_argc, const void * i_argp
     u8* base = runtime->base;
     u8* base_pc = runtime->base_transient;
     M3MemoryHeader* _mem = runtime->memory.mallocated;
-    push_suspend_ptr(pc_t, i_function->compiled, base_pc);
-    push_suspend_ptr(m3stack_t, (m3stack_t)(runtime->stack), base);
-    push_suspend(SuspendTag, m3_st_m3_Call);
+    op_push_suspend_ptr(i_function, base_pc);
+    op_push_suspend(SuspendTag, m3_st_m3_Call);
     // printf("push m3_call\r\n");
 
     M3Result r = (M3Result) Call (i_function->compiled, (m3stack_t)(runtime->stack), _mem, d_m3OpDefaultArgs);
 
-    if (r != m3Err_ComputationBlock)
+    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
     {
         // update memory view after potential memgrow
         //
         M3MemoryHeader* _mem = runtime->memory.mallocated;
     
-        SuspendTag t = pop_suspend(SuspendTag);
+        SuspendTag t = op_pop_suspend(SuspendTag);
         if (t != m3_st_m3_Call && t != m3_st_Sentinel)
         {
             // printf("\r\n m3_Call popped tag: %u at %d \r\n", t, runtime->edge_suspend);
             return "m3_Call mismatching tags";
         }
         // printf("pop m3_call\r\n");
-        pop_suspend(m3stack_t);
-        pop_suspend(pc_t);
+        op_pop_suspend_ptr(IM3Function);
     }
 
     ReportNativeStackUsage ();

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -910,7 +910,7 @@ M3Result  m3_Call  (IM3Function i_function, uint32_t i_argc, const void * i_argp
     u8* base = runtime->base;
     u8* base_pc = runtime->base_transient;
     M3MemoryHeader* _mem = runtime->memory.mallocated;
-    op_push_suspend_ptr(i_function, base_pc);
+    op_push_suspend_ptr(i_function, base);
     op_push_suspend(SuspendTag, m3_st_m3_Call);
     // printf("push m3_call\r\n");
 

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -252,7 +252,7 @@ void  Runtime_Release  (IM3Runtime i_runtime)
 
     m3_Free (i_runtime->stack);
     m3_Free (i_runtime->stack_suspend);
-    m3_Free (i_runtime->memory.mallocated);
+    m3_FreeMemory(i_runtime->memory.mallocated);
 }
 
 
@@ -400,7 +400,7 @@ M3Result  ResizeMemory  (IM3Runtime io_runtime, u32 i_numPages)
         if (numPreviousBytes)
             numPreviousBytes += sizeof (M3MemoryHeader);
 
-        void* newMem = m3_Realloc (memory->mallocated, numBytes, numPreviousBytes);
+        void* newMem = m3_ReallocMemory (memory->mallocated, numBytes, numPreviousBytes);
         _throwifnull(newMem);
 
         memory->mallocated = (M3MemoryHeader*)newMem;

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -185,6 +185,24 @@ IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes
             runtime->numStackSlots = i_stackSizeInBytes / sizeof (m3slot_t);         m3log (runtime, "new stack: %p", runtime->stack);
         }
         else m3_Free (runtime);
+
+        
+        size_t stack_suspend_bytes = (
+            (i_stackSizeInBytes + (sizeof(m3slot_t) - 1))
+            & ~(sizeof(m3slot_t) - 1)   // round up to a multiple of sizeof(m3slot_t)
+        );
+        
+        runtime->stack_suspend = m3_Malloc(stack_suspend_bytes);
+
+        if (runtime->stack_suspend)
+        {
+            runtime->size_suspend = stack_suspend_bytes / sizeof(m3slot_t);
+        }
+        else
+        {
+            m3_Free(runtime->stack);
+            m3_Free(runtime);
+        }
     }
 
     return runtime;
@@ -231,6 +249,7 @@ void  Runtime_Release  (IM3Runtime i_runtime)
     Environment_ReleaseCodePages (i_runtime->environment, i_runtime->pagesFull);
 
     m3_Free (i_runtime->stack);
+    m3_Free (i_runtime->stack_suspend);
     m3_Free (i_runtime->memory.mallocated);
 }
 

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -915,22 +915,23 @@ M3Result  m3_Call  (IM3Function i_function, uint32_t i_argc, const void * i_argp
     // printf("push m3_call\r\n");
 
     M3Result r = (M3Result) Call (i_function->compiled, (m3stack_t)(runtime->stack), _mem, d_m3OpDefaultArgs);
-
-    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
+    if (r == m3Err_ComputationBlock || r == m3Err_SuspensionError)
     {
-        // update memory view after potential memgrow
-        //
-        M3MemoryHeader* _mem = runtime->memory.mallocated;
-    
-        SuspendTag t = op_pop_suspend(SuspendTag);
-        if (t != m3_st_m3_Call && t != m3_st_Sentinel)
-        {
-            // printf("\r\n m3_Call popped tag: %u at %d \r\n", t, runtime->edge_suspend);
-            return "m3_Call mismatching tags";
-        }
-        // printf("pop m3_call\r\n");
-        op_pop_suspend_ptr(IM3Function);
+        return r;
     }
+
+    // update memory view after potential memgrow
+    //
+    _mem = runtime->memory.mallocated;
+
+    SuspendTag t = op_pop_suspend(SuspendTag);
+    if (t != m3_st_m3_Call && t != m3_st_Sentinel)
+    {
+        // printf("\r\n m3_Call popped tag: %u at %d \r\n", t, runtime->edge_suspend);
+        return "m3_Call mismatching tags";
+    }
+    // printf("pop m3_call\r\n");
+    op_pop_suspend_ptr(IM3Function);
 
     ReportNativeStackUsage ();
 

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -167,7 +167,7 @@ void  Environment_ReleaseCodePages  (IM3Environment i_environment, IM3CodePage i
 }
 
 
-IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes, void * i_userdata)
+IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes, void * i_userdata, bool suspend)
 {
     IM3Runtime runtime = m3_AllocStruct (M3Runtime);
 
@@ -186,22 +186,24 @@ IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes
         }
         else m3_Free (runtime);
 
-        
-        size_t stack_suspend_bytes = (
-            (i_stackSizeInBytes + (sizeof(m3slot_t) - 1))
-            & ~(sizeof(m3slot_t) - 1)   // round up to a multiple of sizeof(m3slot_t)
-        );
-        
-        runtime->stack_suspend = m3_Malloc(stack_suspend_bytes);
-
-        if (runtime->stack_suspend)
+        if (suspend)
         {
-            runtime->size_suspend = stack_suspend_bytes / sizeof(m3slot_t);
-        }
-        else
-        {
-            m3_Free(runtime->stack);
-            m3_Free(runtime);
+            size_t stack_suspend_bytes = (
+                (i_stackSizeInBytes + (sizeof(m3slot_t) - 1))
+                & ~(sizeof(m3slot_t) - 1)   // round up to a multiple of sizeof(m3slot_t)
+            );
+            
+            runtime->stack_suspend = m3_Malloc(stack_suspend_bytes);
+    
+            if (runtime->stack_suspend)
+            {
+                runtime->size_suspend = stack_suspend_bytes / sizeof(m3slot_t);
+            }
+            else
+            {
+                m3_Free(runtime->stack);
+                m3_Free(runtime);
+            }
         }
     }
 
@@ -904,11 +906,37 @@ M3Result  m3_Call  (IM3Function i_function, uint32_t i_argc, const void * i_argp
     }
 
     m3StackCheckInit();
-    M3Result r = (M3Result) Call (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+
+    u8* base = runtime->base;
+    u8* base_pc = runtime->base_transient;
+    M3MemoryHeader* _mem = runtime->memory.mallocated;
+    push_suspend_ptr(pc_t, i_function->compiled, base_pc);
+    push_suspend_ptr(m3stack_t, (m3stack_t)(runtime->stack), base);
+    push_suspend(SuspendTag, m3_st_m3_Call);
+    // printf("push m3_call\r\n");
+
+    M3Result r = (M3Result) Call (i_function->compiled, (m3stack_t)(runtime->stack), _mem, d_m3OpDefaultArgs);
+
+    if (r != m3Err_ComputationBlock)
+    {
+        // update memory view after potential memgrow
+        //
+        M3MemoryHeader* _mem = runtime->memory.mallocated;
+    
+        SuspendTag t = pop_suspend(SuspendTag);
+        if (t != m3_st_m3_Call && t != m3_st_Sentinel)
+        {
+            // printf("\r\n m3_Call popped tag: %u at %d \r\n", t, runtime->edge_suspend);
+            return "m3_Call mismatching tags";
+        }
+        // printf("pop m3_call\r\n");
+        pop_suspend(m3stack_t);
+        pop_suspend(pc_t);
+    }
+
     ReportNativeStackUsage ();
 
     runtime->lastCalled = r ? NULL : i_function;
-
 
     return r;
 }

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -178,7 +178,6 @@ typedef struct M3Runtime
     IM3Function             lastCalled;     // last function that successfully executed
 
     void *                  userdata;
-    void *                  userdata_import;  // for imported functions after suspension, TODO different datas for different functions
     void *                  userdata_resume;
 
     M3Memory                memory;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -171,7 +171,7 @@ typedef struct M3Runtime
     m3slot_t *              stack_suspend;
     u32                     edge_suspend;
     u32                     size_suspend;
-    M3Result(*              resume_external     )(M3Result, IM3Runtime);  // [result, runtime, userdata_resume] -> result; external handler
+    const M3Result(*        resume_external     )(M3Result, IM3Runtime);  // [result, runtime, userdata_resume] -> result; external handler
     u8 *                    base;           // start of the memory arena for persistent computations
     u8 *                    base_transient; // start of the memory arena for transient data
     u32                     numStackSlots;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -168,11 +168,16 @@ typedef struct M3Runtime
     IM3Module               modules;        // linked list of imported modules
 
     void *                  stack;
-    u32                     stackSize;
+    m3slot_t *              stack_suspend;
+    u32                     edge_suspend;
+    u32                     size_suspend;
+    u8 *                    base;           // start of the memory arena for persistent computations
+    u8 *                    base_transient; // start of the memory arena for transient data
     u32                     numStackSlots;
     IM3Function             lastCalled;     // last function that successfully executed
 
     void *                  userdata;
+    void *                  userdata_import;  // for imported functions after suspension, TODO different datas for different functions
 
     M3Memory                memory;
     u32                     memoryLimit;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -171,6 +171,7 @@ typedef struct M3Runtime
     m3slot_t *              stack_suspend;
     u32                     edge_suspend;
     u32                     size_suspend;
+    M3Result(*              resume_external     )(M3Result, IM3Runtime);  // [result, runtime, userdata_resume] -> result; external handler
     u8 *                    base;           // start of the memory arena for persistent computations
     u8 *                    base_transient; // start of the memory arena for transient data
     u32                     numStackSlots;
@@ -178,6 +179,7 @@ typedef struct M3Runtime
 
     void *                  userdata;
     void *                  userdata_import;  // for imported functions after suspension, TODO different datas for different functions
+    void *                  userdata_resume;
 
     M3Memory                memory;
     u32                     memoryLimit;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -212,6 +212,11 @@ IM3CodePage                 AcquireCodePageWithCapacity (IM3Runtime io_runtime, 
 void                        ReleaseCodePage             (IM3Runtime io_runtime, IM3CodePage i_codePage);
 M3Result                    EvaluateExpression          (IM3Module i_module, void * o_expressed, u8 i_type, bytes_t * io_bytes, cbytes_t i_end);
 
+M3Result    m3_SuspendStackPush64       (IM3Runtime runtime, u64 value);
+M3Result    m3_SuspendStackPop64        (IM3Runtime runtime, u64* out);
+M3Result    m3_SuspendStackPushExtTag   (IM3Runtime runtime);
+M3Result    m3_SuspendStackPopExtTag    (IM3Runtime runtime);
+
 d_m3EndExternC
 
 #endif // m3_env_h

--- a/source/m3_exec.c
+++ b/source/m3_exec.c
@@ -71,75 +71,83 @@ void  m3_PrintProfilerInfo  () {}
 M3Result
 m3_SuspendStackPush64(IM3Runtime runtime, u64 value)
 {
+    M3Result result = m3Err_none;
     if (runtime->stack_suspend)
     {
         u32 edge = runtime->edge_suspend;
         if (edge + slots_of(u64) > runtime->size_suspend)
         {
-            return m3Err_trapStackOverflow;
+            result =  m3Err_trapStackOverflow;
         }
-        *(u64*)(runtime->stack_suspend + edge) = value;
-        runtime->edge_suspend += slots_of(u64);
+        else
+        {
+            *(u64*)(runtime->stack_suspend + edge) = value;
+            runtime->edge_suspend += slots_of(u64);
+        }
     }
-    else
-    {
-        return m3Err_NoSuspensionStack;
-    }
+    return result;
 }
 
 M3Result
 m3_SuspendStackPop64(IM3Runtime runtime, u64* out)
 {
+    M3Result result = m3Err_none;
     if (runtime->stack_suspend)
     {
-        u32 edge = runtime->edge_suspend -= slots_of(u64);
-        *out = (*(u64 *)(runtime->stack_suspend + edge));
-        return m3Err_none;
+        if (out)
+        {    
+            u32 edge = runtime->edge_suspend -= slots_of(u64);
+            *out = (*(u64 *)(runtime->stack_suspend + edge));
+        }
+        else
+        {
+            runtime->edge_suspend -= slots_of(u64);
+        }
     }
-    else
+    else if (out)
     {
-        return m3Err_NoSuspensionStack;
+        *out = m3_st_Sentinel;
     }
+    return result;
 }
 
 M3Result
 m3_SuspendStackPushExtTag(IM3Runtime runtime)
 {
+    M3Result result = m3Err_none;
     if (runtime->stack_suspend)
     {
         SuspendTag tag = m3_st_External;
         u32 edge = runtime->edge_suspend;
         if (edge + slots_of(SuspendTag) > runtime->size_suspend)
         {
-            return m3Err_trapStackOverflow;
+            result = m3Err_trapStackOverflow;
         }
-        *(SuspendTag*)(runtime->stack_suspend + edge) = tag;
-        runtime->edge_suspend += slots_of(SuspendTag);
+        else
+        {
+            *(SuspendTag*)(runtime->stack_suspend + edge) = tag;
+            runtime->edge_suspend += slots_of(SuspendTag);
+        }
     }
-    else
-    {
-        return m3Err_NoSuspensionStack;
-    }
+    return result;
 }
 
 M3Result
 m3_SuspendStackPopExtTag(IM3Runtime runtime)
 {
+    M3Result result = m3Err_none;
     if (runtime->stack_suspend)
     {
         u32 edge = runtime->edge_suspend -= slots_of(SuspendTag);
         SuspendTag tag = (*(SuspendTag*)(runtime->stack_suspend + edge));
         if (tag != m3_st_External && tag != m3_st_Sentinel)
         {
-            return "External tag mismatch";
+            result =  "External tag mismatch";
         }
         else
         {
-            return m3Err_none;
+            result = m3Err_none;
         }
     }
-    else
-    {
-        return m3Err_NoSuspensionStack;
-    }
+    return result;
 }

--- a/source/m3_exec.c
+++ b/source/m3_exec.c
@@ -67,3 +67,79 @@ void  m3_PrintProfilerInfo  ()
 void  m3_PrintProfilerInfo  () {}
 
 # endif
+
+M3Result
+m3_SuspendStackPush64(IM3Runtime runtime, u64 value)
+{
+    if (runtime->stack_suspend)
+    {
+        u32 edge = runtime->edge_suspend;
+        if (edge + slots_of(u64) > runtime->size_suspend)
+        {
+            return m3Err_trapStackOverflow;
+        }
+        *(u64*)(runtime->stack_suspend + edge) = value;
+        runtime->edge_suspend += slots_of(u64);
+    }
+    else
+    {
+        return m3Err_NoSuspensionStack;
+    }
+}
+
+M3Result
+m3_SuspendStackPop64(IM3Runtime runtime, u64* out)
+{
+    if (runtime->stack_suspend)
+    {
+        u32 edge = runtime->edge_suspend -= slots_of(u64);
+        *out = (*(u64 *)(runtime->stack_suspend + edge));
+        return m3Err_none;
+    }
+    else
+    {
+        return m3Err_NoSuspensionStack;
+    }
+}
+
+M3Result
+m3_SuspendStackPushExtTag(IM3Runtime runtime)
+{
+    if (runtime->stack_suspend)
+    {
+        SuspendTag tag = m3_st_External;
+        u32 edge = runtime->edge_suspend;
+        if (edge + slots_of(SuspendTag) > runtime->size_suspend)
+        {
+            return m3Err_trapStackOverflow;
+        }
+        *(SuspendTag*)(runtime->stack_suspend + edge) = tag;
+        runtime->edge_suspend += slots_of(SuspendTag);
+    }
+    else
+    {
+        return m3Err_NoSuspensionStack;
+    }
+}
+
+M3Result
+m3_SuspendStackPopExtTag(IM3Runtime runtime)
+{
+    if (runtime->stack_suspend)
+    {
+        u32 edge = runtime->edge_suspend -= slots_of(SuspendTag);
+        SuspendTag tag = (*(SuspendTag*)(runtime->stack_suspend + edge));
+        if (tag != m3_st_External && tag != m3_st_Sentinel)
+        {
+            return "External tag mismatch";
+        }
+        else
+        {
+            return m3Err_none;
+        }
+    }
+    else
+    {
+        return m3Err_NoSuspensionStack;
+    }
+}

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -783,7 +783,14 @@ d_m3Op  (CallRawFunction)
     // printf("push CallRaw\r\n");
 
     m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
-    runtime->stack = stack_backup;
+
+    // we are not done if we are blocked, so don't restore the stack yet
+    //
+    if (possible_trap != m3Err_ComputationBlock
+        && possible_trap != m3Err_SuspensionError)
+    {
+        runtime->stack = stack_backup;
+    }
     _mem = memory->mallocated;
 
 #if d_m3EnableStrace

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -115,33 +115,54 @@ d_m3BeginExternC
 // PUSH and POP for suspension frames require scalar types
 // push structs by pushing their fields
 // convert pointers to offsets before pushing
+//
+// m3_Call MUST be used as the entry point for function invocation
+// (not m3_CallV, m3_CallArgv, etc)
 
-#define push_suspend(TYPE, VAL)                                     \
-    do {                                                            \
-        u32* edge = &_mem->runtime->edge_suspend;                   \
-        if (*edge + slots_of(TYPE) > _mem->runtime->size_suspend)   \
-        {                                                           \
-            return m3Err_trapStackOverflow;                         \
-        }                                                           \
-        *(TYPE*)(_mem->runtime->stack_suspend + *edge) = (VAL);     \
-        *edge += slots_of(TYPE);                                    \
+#define push_suspend(TYPE, VAL)                                         \
+    do {                                                                \
+        if (_mem->runtime->stack_suspend)                               \
+        {                                                               \
+            u32 edge = _mem->runtime->edge_suspend;                     \
+            if (edge + slots_of(TYPE) > _mem->runtime->size_suspend)    \
+            {                                                           \
+                return m3Err_trapStackOverflow;                         \
+            }                                                           \
+            *(TYPE*)(_mem->runtime->stack_suspend + edge) = (VAL);      \
+            _mem->runtime->edge_suspend += slots_of(TYPE);              \
+        }                                                               \
     } while (0)
 
-#define pop_suspend(TYPE)                                   \
-    ( *(TYPE*)(                                             \
-        _mem->runtime->stack_suspend                        \
-        + (_mem->runtime->edge_suspend -= slots_of(TYPE))   \
-    ) )
+#define pop_suspend(TYPE)                                       \
+    (_mem->runtime->stack_suspend)                              \
+        ? ( *(TYPE*)(                                           \
+            _mem->runtime->stack_suspend                        \
+            + (_mem->runtime->edge_suspend -= slots_of(TYPE))   \
+            ) )                                                 \
+        : (TYPE)POPVAL_SENTINEL
+
+#define peek_suspend(TYPE)                                      \
+    (_mem->runtime->stack_suspend)                              \
+        ? ( *(TYPE*)(                                           \
+            _mem->runtime->stack_suspend                        \
+            + (_mem->runtime->edge_suspend - slots_of(TYPE))    \
+            ) )                                                 \
+        : (TYPE)POPVAL_SENTINEL
+
+#define POPVAL_SENTINEL m3_st_Sentinel
 
 #define push_suspend_ptr(TYPE, VAL, BASE)       \
     push_suspend(TYPE, TO_OFF(TYPE, VAL, BASE))
 
 typedef enum {
-    st_Call,
-    st_Call_indirect,
-    st_CallRaw,
-    st_Entry,
-    st_Loop,
+    m3_st_Sentinel = -1,
+    m3_st_External,
+    m3_st_Call,
+    m3_st_Call_indirect,
+    m3_st_CallRaw,
+    m3_st_Entry,
+    m3_st_Loop,
+    m3_st_m3_Call,
 } SuspendTag;
 
 d_m3RetSig  Call  (d_m3OpSig)
@@ -598,18 +619,21 @@ d_m3Op  (Call)
     push_suspend_ptr(m3stack_t, _sp, base);
     push_suspend(m3reg_t, _r0);
     push_suspend(f64, _fp0);
-    push_suspend(SuspendTag, st_Call);
+    push_suspend(SuspendTag, m3_st_Call);
+    // printf("push Call\r\n");
 
     m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
     _mem = memory->mallocated;
 
-    if (LIKELY(not r))
+    if (r != m3Err_ComputationBlock)
     {
+        u32 edge_1 = _mem->runtime->edge_suspend;
         SuspendTag t = pop_suspend(SuspendTag);
-        if (t != st_Call)
+        if (t != m3_st_Call && t != m3_st_Sentinel)
         {
             return "Call mismatching tags";
         }
+        // printf("pop Call\r\n");
         pop_suspend(f64);
         pop_suspend(m3reg_t);
         pop_suspend(m3stack_t);
@@ -618,6 +642,12 @@ d_m3Op  (Call)
         pop_suspend(M3MemoryHeader*);
         pop_suspend(m3stack_t);
         pop_suspend(pc_t);
+        u32 edge_2 = _mem->runtime->edge_suspend;
+        // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
+    }
+
+    if (LIKELY(not r))
+    {
         nextOp ();
     }
     else
@@ -663,18 +693,20 @@ d_m3Op  (CallIndirect)
                     push_suspend_ptr(m3stack_t, _sp, base);
                     push_suspend(m3reg_t, _r0);
                     push_suspend(f64, _fp0);
-                    push_suspend(SuspendTag, st_Call_indirect);
+                    push_suspend(SuspendTag, m3_st_Call_indirect);
+                    // printf("push Call_indirect\r\n");
 
                     r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
                     _mem = memory->mallocated;
 
-                    if (LIKELY(not r))
+                    if (r != m3Err_ComputationBlock)
                     {
                         SuspendTag t = pop_suspend(SuspendTag);
-                        if (t != st_Call_indirect)
+                        if (t != m3_st_Call_indirect && t != m3_st_Sentinel)
                         {
                             return "CallIndirect mismatching tags";
                         }
+                        // printf("pop Call_indirect\r\n");
                         pop_suspend(f64);
                         pop_suspend(m3reg_t);
                         pop_suspend(m3stack_t);
@@ -683,6 +715,10 @@ d_m3Op  (CallIndirect)
                         pop_suspend(M3MemoryHeader*);
                         pop_suspend(m3stack_t);
                         pop_suspend(u32);
+                    }
+
+                    if (LIKELY(not r))
+                    {
                         nextOpDirect ();
                     }
                     else
@@ -761,10 +797,12 @@ d_m3Op  (CallRawFunction)
     push_suspend_ptr(IM3Function, ctx.function, base);
     //  ctx.userdata to be filled during replay
     push_suspend_ptr(M3RawCall*, call_p, base_pc);
-    push_suspend(SuspendTag, st_CallRaw);
+    push_suspend(SuspendTag, m3_st_CallRaw);
+    // printf("push CallRaw\r\n");
 
     m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
     runtime->stack = stack_backup;
+    _mem = memory->mallocated;
 
 #if d_m3EnableStrace
     if (UNLIKELY(possible_trap)) {
@@ -780,21 +818,22 @@ d_m3Op  (CallRawFunction)
     }
 #endif
 
-    if (UNLIKELY(possible_trap)) {
-        _mem = memory->mallocated;
-        pushBacktraceFrame ();
-    }
-    else {
-        _mem = memory->mallocated;
+    if (possible_trap != m3Err_ComputationBlock)
+    {
         SuspendTag t = pop_suspend(SuspendTag);
-        if (t != st_CallRaw)
+        if (t != m3_st_CallRaw && t != m3_st_Sentinel)
         {
             return "CallRaw mismatching tags";
         }
+        // printf("pop CallRaw\r\n");
         pop_suspend(M3RawCall*);
         pop_suspend(IM3Function);
         pop_suspend(u8*);
         pop_suspend(u64*);
+    }
+
+    if (UNLIKELY(possible_trap)) {
+        pushBacktraceFrame ();
     }
     forwardTrap (possible_trap);
 }
@@ -941,9 +980,11 @@ d_m3Op  (Entry)
         push_suspend(m3reg_t, _r0);
         push_suspend(f64, _fp0);
         push_suspend_ptr(IM3Memory, memory, base);
-        push_suspend(SuspendTag, st_Entry);
+        push_suspend(SuspendTag, m3_st_Entry);
+        // printf("push Entry\r\n");
 
         m3ret_t r = nextOpImpl ();
+        _mem = memory->mallocated;
 
 #if d_m3EnableStrace >= 2
         trace_rt->callDepth--;
@@ -962,23 +1003,37 @@ d_m3Op  (Entry)
         }
 #endif
 
-        if (UNLIKELY(r)) {
-            _mem = memory->mallocated;
-            fillBacktraceFrame ();
-        }
-        else {
-            _mem = memory->mallocated;
-            SuspendTag t = pop_suspend(SuspendTag);
-            if (t != st_Entry)
+        if (r != m3Err_ComputationBlock)
+        {
+            SuspendTag t;
+            if (r)
+            {
+                while (t = peek_suspend(SuspendTag), t == m3_st_Loop)
+                {
+                    // printf("pop Loop\r\n");
+                    pop_suspend(SuspendTag);
+                    pop_suspend(IM3Memory);
+                    pop_suspend(m3stack_t);
+                    pop_suspend(pc_t);
+                }
+            }
+
+            t = pop_suspend(SuspendTag);
+            if (t != m3_st_Entry && t != m3_st_Sentinel)
             {
                 return "Entry mismatching tags";
             }
+            // printf("pop Entry\r\n");
             pop_suspend(IM3Memory);
             pop_suspend(f64);
             pop_suspend(m3reg_t);
             pop_suspend(M3MemoryHeader*);
             pop_suspend(m3stack_t);
             pop_suspend(pc_t);
+        }
+
+        if (UNLIKELY(r)) {
+            fillBacktraceFrame ();
         }
         forwardTrap (r);
     }
@@ -1004,7 +1059,8 @@ d_m3Op  (Loop)
     push_suspend_ptr(m3stack_t, _sp, base);
     push_suspend_ptr(IM3Memory, memory, base);
     // registers are zeros
-    push_suspend(SuspendTag, st_Loop);
+    push_suspend(SuspendTag, m3_st_Loop);
+    // printf("push Loop\r\n");
 
     do
     {
@@ -1023,8 +1079,10 @@ d_m3Op  (Loop)
         _mem = memory->mallocated;
     }
     while (r == _pc);
-    // we end up here after the end of the loop, but we need to pop the suspension
-    // stack right at the end of the loop, see d_m3Op(SuspendPopLoop) and others
+    // we end up here either after the loops were normally terminated/jumped out
+    // of, or if the computation terminated early due to an error.
+    // In the former case we won't have loop frames to pop. In the latter case
+    // we might have some, and op_Entry will pop them for us.
     //
     forwardTrap (r);
 }
@@ -1304,10 +1362,11 @@ d_m3Op  (BranchIf_r)
         while (num_loops--)
         {
             SuspendTag t = pop_suspend(SuspendTag);
-            if (t != st_Loop)
+            if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
+            // printf("pop Loop\r\n");
             pop_suspend(IM3Memory);
             pop_suspend(m3stack_t);
             pop_suspend(pc_t);
@@ -1329,10 +1388,11 @@ d_m3Op  (BranchIf_s)
         while (num_loops--)
         {
             SuspendTag t = pop_suspend(SuspendTag);
-            if (t != st_Loop)
+            if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
+            // printf("pop Loop\r\n");
             pop_suspend(IM3Memory);
             pop_suspend(m3stack_t);
             pop_suspend(pc_t);
@@ -1395,10 +1455,11 @@ d_m3Op  (ContinueLoopIf)
         while (num_loops--)
         {
             SuspendTag t = pop_suspend(SuspendTag);
-            if (t != st_Loop)
+            if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
+            // printf("pop Loop\r\n");
             pop_suspend(IM3Memory);
             pop_suspend(m3stack_t);
             pop_suspend(pc_t);
@@ -1449,10 +1510,11 @@ d_m3Op  (SuspendPopLoop)
     while (num_loops--)
     {
         SuspendTag t = pop_suspend(SuspendTag);
-        if (t != st_Loop)
+        if (t != m3_st_Loop && t != m3_st_Sentinel)
         {
             return "Loop mismatching tags";
         }
+        // printf("pop Loop\r\n");
         pop_suspend(IM3Memory);
         pop_suspend(m3stack_t);
         pop_suspend(pc_t);

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -28,6 +28,7 @@
 #include "m3_env.h"
 #include "m3_info.h"
 #include "m3_exec_defs.h"
+#include "m3_rewrite.h"
 
 #include <limits.h>
 
@@ -106,6 +107,42 @@ d_m3BeginExternC
 
 #endif
 
+// how many slots to store a type
+//
+#define slots_of(TYPE)                                          \
+    ( (sizeof(TYPE) + sizeof(m3slot_t) - 1) / sizeof(m3slot_t) )
+
+// PUSH and POP for suspension frames require scalar types
+// push structs by pushing their fields
+// convert pointers to offsets before pushing
+
+#define push_suspend(TYPE, VAL)                                     \
+    do {                                                            \
+        u32* edge = &_mem->runtime->edge_suspend;                   \
+        if (*edge + slots_of(TYPE) > _mem->runtime->size_suspend)   \
+        {                                                           \
+            return m3Err_trapStackOverflow;                         \
+        }                                                           \
+        *(TYPE*)(_mem->runtime->stack_suspend + *edge) = (VAL);     \
+        *edge += slots_of(TYPE);                                    \
+    } while (0)
+
+#define pop_suspend(TYPE)                                   \
+    ( *(TYPE*)(                                             \
+        _mem->runtime->stack_suspend                        \
+        + (_mem->runtime->edge_suspend -= slots_of(TYPE))   \
+    ) )
+
+#define push_suspend_ptr(TYPE, VAL, BASE)       \
+    push_suspend(TYPE, TO_OFF(TYPE, VAL, BASE))
+
+typedef enum {
+    st_Call,
+    st_Call_indirect,
+    st_CallRaw,
+    st_Entry,
+    st_Loop,
+} SuspendTag;
 
 d_m3RetSig  Call  (d_m3OpSig)
 {
@@ -551,11 +588,38 @@ d_m3Op  (Call)
 
     m3stack_t sp = _sp + stackOffset;
 
+    u8* base = _mem->runtime->base;
+    u8* base_pc = _mem->runtime->base_transient;
+    push_suspend_ptr(pc_t, callPC, base_pc);
+    push_suspend_ptr(m3stack_t, sp, base);
+    push_suspend_ptr(M3MemoryHeader*, _mem, base);
+    push_suspend_ptr(IM3Memory, memory, base);
+    push_suspend_ptr(pc_t, _pc, base_pc);
+    push_suspend_ptr(m3stack_t, _sp, base);
+    push_suspend(m3reg_t, _r0);
+    push_suspend(f64, _fp0);
+    push_suspend(SuspendTag, st_Call);
+
     m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
     _mem = memory->mallocated;
 
     if (LIKELY(not r))
+    {
+        SuspendTag t = pop_suspend(SuspendTag);
+        if (t != st_Call)
+        {
+            return "Call mismatching tags";
+        }
+        pop_suspend(f64);
+        pop_suspend(m3reg_t);
+        pop_suspend(m3stack_t);
+        pop_suspend(pc_t);
+        pop_suspend(IM3Memory);
+        pop_suspend(M3MemoryHeader*);
+        pop_suspend(m3stack_t);
+        pop_suspend(pc_t);
         nextOp ();
+    }
     else
     {
         pushBacktraceFrame ();
@@ -589,11 +653,38 @@ d_m3Op  (CallIndirect)
 
                 if (LIKELY(not r))
                 {
+                    u8* base = _mem->runtime->base;
+                    u8* base_pc = _mem->runtime->base_transient;
+                    push_suspend(u32, tableIndex);
+                    push_suspend_ptr(m3stack_t, sp, base);
+                    push_suspend_ptr(M3MemoryHeader*, _mem, base);
+                    push_suspend_ptr(IM3Memory, memory, base);
+                    push_suspend_ptr(pc_t, _pc, base_pc);
+                    push_suspend_ptr(m3stack_t, _sp, base);
+                    push_suspend(m3reg_t, _r0);
+                    push_suspend(f64, _fp0);
+                    push_suspend(SuspendTag, st_Call_indirect);
+
                     r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
                     _mem = memory->mallocated;
 
                     if (LIKELY(not r))
+                    {
+                        SuspendTag t = pop_suspend(SuspendTag);
+                        if (t != st_Call_indirect)
+                        {
+                            return "CallIndirect mismatching tags";
+                        }
+                        pop_suspend(f64);
+                        pop_suspend(m3reg_t);
+                        pop_suspend(m3stack_t);
+                        pop_suspend(pc_t);
+                        pop_suspend(IM3Memory);
+                        pop_suspend(M3MemoryHeader*);
+                        pop_suspend(m3stack_t);
+                        pop_suspend(u32);
                         nextOpDirect ();
+                    }
                     else
                     {
                         pushBacktraceFrame ();
@@ -619,7 +710,8 @@ d_m3Op  (CallRawFunction)
 
     M3ImportContext ctx;
 
-    M3RawCall call = (M3RawCall) (* _pc++);
+    M3RawCall* call_p = _pc++;
+    M3RawCall call = *call_p;
     ctx.function = immediate (IM3Function);
     ctx.userdata = immediate (void *);
     u64* const sp = ((u64*)_sp);
@@ -661,6 +753,16 @@ d_m3Op  (CallRawFunction)
     // I.e. exported/table function can be called from an impoted function.
     void* stack_backup = runtime->stack;
     runtime->stack = sp;
+
+    u8* base = _mem->runtime->base;
+    u8* base_pc = _mem->runtime->base_transient;
+    push_suspend_ptr(u64*, sp, base);
+    push_suspend_ptr(u8*, m3MemData(_mem), base);
+    push_suspend_ptr(IM3Function, ctx.function, base);
+    //  ctx.userdata to be filled during replay
+    push_suspend_ptr(M3RawCall*, call_p, base_pc);
+    push_suspend(SuspendTag, st_CallRaw);
+
     m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
     runtime->stack = stack_backup;
 
@@ -681,6 +783,18 @@ d_m3Op  (CallRawFunction)
     if (UNLIKELY(possible_trap)) {
         _mem = memory->mallocated;
         pushBacktraceFrame ();
+    }
+    else {
+        _mem = memory->mallocated;
+        SuspendTag t = pop_suspend(SuspendTag);
+        if (t != st_CallRaw)
+        {
+            return "CallRaw mismatching tags";
+        }
+        pop_suspend(M3RawCall*);
+        pop_suspend(IM3Function);
+        pop_suspend(u8*);
+        pop_suspend(u64*);
     }
     forwardTrap (possible_trap);
 }
@@ -819,6 +933,16 @@ d_m3Op  (Entry)
         trace_rt->callDepth++;
 #endif
 
+        u8* base = _mem->runtime->base;
+        u8* base_pc = _mem->runtime->base_transient;
+        push_suspend_ptr(pc_t, _pc, base_pc);
+        push_suspend_ptr(m3stack_t, _sp, base);
+        push_suspend_ptr(M3MemoryHeader*, _mem, base);
+        push_suspend(m3reg_t, _r0);
+        push_suspend(f64, _fp0);
+        push_suspend_ptr(IM3Memory, memory, base);
+        push_suspend(SuspendTag, st_Entry);
+
         m3ret_t r = nextOpImpl ();
 
 #if d_m3EnableStrace >= 2
@@ -842,6 +966,20 @@ d_m3Op  (Entry)
             _mem = memory->mallocated;
             fillBacktraceFrame ();
         }
+        else {
+            _mem = memory->mallocated;
+            SuspendTag t = pop_suspend(SuspendTag);
+            if (t != st_Entry)
+            {
+                return "Entry mismatching tags";
+            }
+            pop_suspend(IM3Memory);
+            pop_suspend(f64);
+            pop_suspend(m3reg_t);
+            pop_suspend(M3MemoryHeader*);
+            pop_suspend(m3stack_t);
+            pop_suspend(pc_t);
+        }
         forwardTrap (r);
     }
     else newTrap (m3Err_trapStackOverflow);
@@ -860,6 +998,14 @@ d_m3Op  (Loop)
 
     IM3Memory memory = m3MemInfo (_mem);
 
+    u8* base = _mem->runtime->base;
+    u8* base_pc = _mem->runtime->base_transient;
+    push_suspend_ptr(pc_t, _pc, base_pc);
+    push_suspend_ptr(m3stack_t, _sp, base);
+    push_suspend_ptr(IM3Memory, memory, base);
+    // registers are zeros
+    push_suspend(SuspendTag, st_Loop);
+
     do
     {
 #if d_m3EnableStrace >= 3
@@ -877,7 +1023,9 @@ d_m3Op  (Loop)
         _mem = memory->mallocated;
     }
     while (r == _pc);
-
+    // we end up here after the end of the loop, but we need to pop the suspension
+    // stack right at the end of the loop, see d_m3Op(SuspendPopLoop) and others
+    //
     forwardTrap (r);
 }
 
@@ -1148,10 +1296,22 @@ d_m3Op  (Return)
 d_m3Op  (BranchIf_r)
 {
     i32 condition   = (i32) _r0;
+    u32 num_loops   = immediate(u32);
     pc_t branch     = immediate (pc_t);
 
     if (condition)
     {
+        while (num_loops--)
+        {
+            SuspendTag t = pop_suspend(SuspendTag);
+            if (t != st_Loop)
+            {
+                return "Loop mismatching tags";
+            }
+            pop_suspend(IM3Memory);
+            pop_suspend(m3stack_t);
+            pop_suspend(pc_t);
+        }
         jumpOp (branch);
     }
     else nextOp ();
@@ -1160,11 +1320,23 @@ d_m3Op  (BranchIf_r)
 
 d_m3Op  (BranchIf_s)
 {
+    u32 num_loops   = immediate(u32);
     i32 condition   = slot (i32);
     pc_t branch     = immediate (pc_t);
 
     if (condition)
     {
+        while (num_loops--)
+        {
+            SuspendTag t = pop_suspend(SuspendTag);
+            if (t != st_Loop)
+            {
+                return "Loop mismatching tags";
+            }
+            pop_suspend(IM3Memory);
+            pop_suspend(m3stack_t);
+            pop_suspend(pc_t);
+        }
         jumpOp (branch);
     }
     else nextOp ();
@@ -1216,9 +1388,21 @@ d_m3Op  (ContinueLoopIf)
 {
     i32 condition = (i32) _r0;
     void * loopId = immediate (void *);
+    u32 num_loops = immediate(u32);
 
     if (condition)
     {
+        while (num_loops--)
+        {
+            SuspendTag t = pop_suspend(SuspendTag);
+            if (t != st_Loop)
+            {
+                return "Loop mismatching tags";
+            }
+            pop_suspend(IM3Memory);
+            pop_suspend(m3stack_t);
+            pop_suspend(pc_t);
+        }
         return loopId;
     }
     else nextOp ();
@@ -1257,6 +1441,24 @@ d_m3Op  (End)
 {
     m3StackCheck();
     return m3Err_none;
+}
+
+d_m3Op  (SuspendPopLoop)
+{
+    u32 num_loops = immediate(u32);
+    while (num_loops--)
+    {
+        SuspendTag t = pop_suspend(SuspendTag);
+        if (t != st_Loop)
+        {
+            return "Loop mismatching tags";
+        }
+        pop_suspend(IM3Memory);
+        pop_suspend(m3stack_t);
+        pop_suspend(pc_t);
+    }
+
+    nextOp ();
 }
 
 

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -162,7 +162,6 @@ typedef enum {
     m3_st_Call,
     m3_st_Call_indirect,
     m3_st_CallRaw,
-    m3_st_Entry,
     m3_st_Loop,
     m3_st_m3_Call,
 } SuspendTag;
@@ -613,7 +612,6 @@ d_m3Op  (Call)
 
     u8* base = _mem->runtime->base;
     u8* base_pc = _mem->runtime->base_transient;
-    op_push_suspend_ptr(memory, base);
     op_push_suspend_ptr(_pc, base_pc);
     op_push_suspend_ptr(_sp, base);
     op_push_suspend(m3reg_t, _r0);
@@ -637,7 +635,6 @@ d_m3Op  (Call)
         op_pop_suspend(m3reg_t);
         op_pop_suspend_ptr(m3stack_t);
         op_pop_suspend_ptr(pc_t);
-        op_pop_suspend_ptr(IM3Memory);
         u32 edge_2 = _mem->runtime->edge_suspend;
         // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
     }
@@ -682,7 +679,6 @@ d_m3Op  (CallIndirect)
                     u8* base = _mem->runtime->base;
                     u8* base_pc = _mem->runtime->base_transient;
 
-                    op_push_suspend_ptr(memory, base);
                     op_push_suspend_ptr(_pc, base_pc);
                     op_push_suspend_ptr(_sp, base);
                     op_push_suspend(m3reg_t, _r0);
@@ -705,7 +701,6 @@ d_m3Op  (CallIndirect)
                         op_pop_suspend(m3reg_t);
                         op_pop_suspend_ptr(m3stack_t);
                         op_pop_suspend_ptr(pc_t);
-                        op_pop_suspend_ptr(IM3Memory);
                         
                     }
 
@@ -957,8 +952,6 @@ d_m3Op  (Entry)
         trace_rt->callDepth++;
 #endif
 
-        op_push_suspend(SuspendTag, m3_st_Entry);
-        // printf("push Entry\r\n");
 
         m3ret_t r = nextOpImpl ();
         _mem = memory->mallocated;
@@ -979,29 +972,6 @@ d_m3Op  (Entry)
             }
         }
 #endif
-
-        if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
-        {
-            SuspendTag t;
-            if (r)
-            {
-                while (t = op_peek_suspend(SuspendTag), t == m3_st_Loop)
-                {
-                    // printf("pop Loop\r\n");
-                    op_pop_suspend(SuspendTag);
-                    op_pop_suspend_ptr(IM3Memory);
-                    op_pop_suspend_ptr(m3stack_t);
-                    op_pop_suspend_ptr(pc_t);
-                }
-            }
-
-            t = op_pop_suspend(SuspendTag);
-            if (t != m3_st_Entry && t != m3_st_Sentinel)
-            {
-                return "Entry mismatching tags";
-            }
-            // printf("pop Entry\r\n");
-        }
 
         if (UNLIKELY(r)) {
             fillBacktraceFrame ();
@@ -1028,7 +998,6 @@ d_m3Op  (Loop)
     u8* base_pc = _mem->runtime->base_transient;
     op_push_suspend_ptr(_pc, base_pc);
     op_push_suspend_ptr(_sp, base);
-    op_push_suspend_ptr(memory, base);
     // registers are zeros
     op_push_suspend(SuspendTag, m3_st_Loop);
     // printf("push Loop\r\n");
@@ -1050,11 +1019,18 @@ d_m3Op  (Loop)
         _mem = memory->mallocated;
     }
     while (r == _pc);
-    // we end up here either after the loops were normally terminated/jumped out
-    // of, or if the computation terminated early due to an error.
-    // In the former case we won't have loop frames to pop. In the latter case
-    // we might have some, and op_Entry will pop them for us.
-    //
+
+    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
+    {
+        SuspendTag t = op_pop_suspend(SuspendTag);
+        if (t != m3_st_Loop && t != m3_st_Sentinel)
+        {
+            return "Loop mismatching tags";
+        }
+        op_pop_suspend_ptr(m3stack_t);
+        op_pop_suspend_ptr(pc_t);
+    }
+    
     forwardTrap (r);
 }
 
@@ -1325,23 +1301,10 @@ d_m3Op  (Return)
 d_m3Op  (BranchIf_r)
 {
     i32 condition   = (i32) _r0;
-    u32 num_loops   = immediate(u32);
     pc_t branch     = immediate (pc_t);
 
     if (condition)
     {
-        while (num_loops--)
-        {
-            SuspendTag t = op_pop_suspend(SuspendTag);
-            if (t != m3_st_Loop && t != m3_st_Sentinel)
-            {
-                return "Loop mismatching tags";
-            }
-            // printf("pop Loop\r\n");
-            op_pop_suspend_ptr(IM3Memory);
-            op_pop_suspend_ptr(m3stack_t);
-            op_pop_suspend_ptr(pc_t);
-        }
         jumpOp (branch);
     }
     else nextOp ();
@@ -1350,24 +1313,11 @@ d_m3Op  (BranchIf_r)
 
 d_m3Op  (BranchIf_s)
 {
-    u32 num_loops   = immediate(u32);
     i32 condition   = slot (i32);
     pc_t branch     = immediate (pc_t);
 
     if (condition)
     {
-        while (num_loops--)
-        {
-            SuspendTag t = op_pop_suspend(SuspendTag);
-            if (t != m3_st_Loop && t != m3_st_Sentinel)
-            {
-                return "Loop mismatching tags";
-            }
-            // printf("pop Loop\r\n");
-            op_pop_suspend_ptr(IM3Memory);
-            op_pop_suspend_ptr(m3stack_t);
-            op_pop_suspend_ptr(pc_t);
-        }
         jumpOp (branch);
     }
     else nextOp ();
@@ -1419,22 +1369,9 @@ d_m3Op  (ContinueLoopIf)
 {
     i32 condition = (i32) _r0;
     void * loopId = immediate (void *);
-    u32 num_loops = immediate(u32);
 
     if (condition)
     {
-        while (num_loops--)
-        {
-            SuspendTag t = op_pop_suspend(SuspendTag);
-            if (t != m3_st_Loop && t != m3_st_Sentinel)
-            {
-                return "Loop mismatching tags";
-            }
-            // printf("pop Loop\r\n");
-            op_pop_suspend_ptr(IM3Memory);
-            op_pop_suspend_ptr(m3stack_t);
-            op_pop_suspend_ptr(pc_t);
-        }
         return loopId;
     }
     else nextOp ();
@@ -1473,25 +1410,6 @@ d_m3Op  (End)
 {
     m3StackCheck();
     return m3Err_none;
-}
-
-d_m3Op  (SuspendPopLoop)
-{
-    u32 num_loops = immediate(u32);
-    while (num_loops--)
-    {
-        SuspendTag t = op_pop_suspend(SuspendTag);
-        if (t != m3_st_Loop && t != m3_st_Sentinel)
-        {
-            return "Loop mismatching tags";
-        }
-        // printf("pop Loop\r\n");
-        op_pop_suspend_ptr(IM3Memory);
-        op_pop_suspend_ptr(m3stack_t);
-        op_pop_suspend_ptr(pc_t);
-    }
-
-    nextOp ();
 }
 
 

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -620,24 +620,25 @@ d_m3Op  (Call)
     // printf("push Call\r\n");
 
     m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
+    if (r == m3Err_ComputationBlock || r == m3Err_SuspensionError)
+    {
+        return r;
+    }
     _mem = memory->mallocated;
 
-    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
+    u32 edge_1 = _mem->runtime->edge_suspend;
+    SuspendTag t = op_pop_suspend(SuspendTag);
+    if (t != m3_st_Call && t != m3_st_Sentinel)
     {
-        u32 edge_1 = _mem->runtime->edge_suspend;
-        SuspendTag t = op_pop_suspend(SuspendTag);
-        if (t != m3_st_Call && t != m3_st_Sentinel)
-        {
-            return "Call mismatching tags";
-        }
-        // printf("pop Call\r\n");
-        op_pop_suspend(f64);
-        op_pop_suspend(m3reg_t);
-        op_pop_suspend_ptr(m3stack_t);
-        op_pop_suspend_ptr(pc_t);
-        u32 edge_2 = _mem->runtime->edge_suspend;
-        // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
+        return "Call mismatching tags";
     }
+    // printf("pop Call\r\n");
+    op_pop_suspend(f64);
+    op_pop_suspend(m3reg_t);
+    op_pop_suspend_ptr(m3stack_t);
+    op_pop_suspend_ptr(pc_t);
+    u32 edge_2 = _mem->runtime->edge_suspend;
+    // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
 
     if (LIKELY(not r))
     {
@@ -687,22 +688,22 @@ d_m3Op  (CallIndirect)
                     // printf("push Call_indirect\r\n");
 
                     r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
+                    if (r == m3Err_ComputationBlock || r == m3Err_SuspensionError)
+                    {
+                        return r;
+                    }
                     _mem = memory->mallocated;
 
-                    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
+                    SuspendTag t = op_pop_suspend(SuspendTag);
+                    if (t != m3_st_Call_indirect && t != m3_st_Sentinel)
                     {
-                        SuspendTag t = op_pop_suspend(SuspendTag);
-                        if (t != m3_st_Call_indirect && t != m3_st_Sentinel)
-                        {
-                            return "CallIndirect mismatching tags";
-                        }
-                        // printf("pop Call_indirect\r\n");
-                        op_pop_suspend(f64);
-                        op_pop_suspend(m3reg_t);
-                        op_pop_suspend_ptr(m3stack_t);
-                        op_pop_suspend_ptr(pc_t);
-                        
+                        return "CallIndirect mismatching tags";
                     }
+                    // printf("pop Call_indirect\r\n");
+                    op_pop_suspend(f64);
+                    op_pop_suspend(m3reg_t);
+                    op_pop_suspend_ptr(m3stack_t);
+                    op_pop_suspend_ptr(pc_t);
 
                     if (LIKELY(not r))
                     {
@@ -783,14 +784,13 @@ d_m3Op  (CallRawFunction)
     // printf("push CallRaw\r\n");
 
     m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
-
-    // we are not done if we are blocked, so don't restore the stack yet
-    //
-    if (possible_trap != m3Err_ComputationBlock
-        && possible_trap != m3Err_SuspensionError)
+    if (possible_trap == m3Err_ComputationBlock
+        || possible_trap == m3Err_SuspensionError)
     {
-        runtime->stack = stack_backup;
+        return possible_trap;
     }
+
+    runtime->stack = stack_backup;
     _mem = memory->mallocated;
 
 #if d_m3EnableStrace
@@ -807,17 +807,13 @@ d_m3Op  (CallRawFunction)
     }
 #endif
 
-    if (possible_trap != m3Err_ComputationBlock
-        && possible_trap != m3Err_SuspensionError)
+    SuspendTag t = op_pop_suspend(SuspendTag);
+    if (t != m3_st_CallRaw && t != m3_st_Sentinel)
     {
-        SuspendTag t = op_pop_suspend(SuspendTag);
-        if (t != m3_st_CallRaw && t != m3_st_Sentinel)
-        {
-            return "CallRaw mismatching tags";
-        }
-        // printf("pop CallRaw\r\n");
-        op_pop_suspend_ptr(void*);
+        return "CallRaw mismatching tags";
     }
+    // printf("pop CallRaw\r\n");
+    op_pop_suspend_ptr(void*);
 
     if (UNLIKELY(possible_trap)) {
         pushBacktraceFrame ();
@@ -1027,16 +1023,18 @@ d_m3Op  (Loop)
     }
     while (r == _pc);
 
-    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
+    if (r == m3Err_ComputationBlock || r == m3Err_SuspensionError)
     {
-        SuspendTag t = op_pop_suspend(SuspendTag);
-        if (t != m3_st_Loop && t != m3_st_Sentinel)
-        {
-            return "Loop mismatching tags";
-        }
-        op_pop_suspend_ptr(m3stack_t);
-        op_pop_suspend_ptr(pc_t);
+        return r;
     }
+
+    SuspendTag t = op_pop_suspend(SuspendTag);
+    if (t != m3_st_Loop && t != m3_st_Sentinel)
+    {
+        return "Loop mismatching tags";
+    }
+    op_pop_suspend_ptr(m3stack_t);
+    op_pop_suspend_ptr(pc_t);
     
     forwardTrap (r);
 }

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -626,7 +626,7 @@ d_m3Op  (Call)
     }
     _mem = memory->mallocated;
 
-    u32 edge_1 = _mem->runtime->edge_suspend;
+    // u32 edge_1 = _mem->runtime->edge_suspend;
     SuspendTag t = op_pop_suspend(SuspendTag);
     if (t != m3_st_Call && t != m3_st_Sentinel)
     {
@@ -637,7 +637,7 @@ d_m3Op  (Call)
     op_pop_suspend(m3reg_t);
     op_pop_suspend_ptr(m3stack_t);
     op_pop_suspend_ptr(pc_t);
-    u32 edge_2 = _mem->runtime->edge_suspend;
+    // u32 edge_2 = _mem->runtime->edge_suspend;
     // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
 
     if (LIKELY(not r))
@@ -734,8 +734,7 @@ d_m3Op  (CallRawFunction)
 
     M3ImportContext ctx;
 
-    M3RawCall* call_p = _pc++;
-    M3RawCall call = *call_p;
+    M3RawCall call = (M3RawCall) (* _pc++);
     ctx.function = immediate (IM3Function);
     ctx.userdata = immediate (void *);
     u64* const sp = ((u64*)_sp);

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -119,7 +119,7 @@ d_m3BeginExternC
 // m3_Call MUST be used as the entry point for function invocation
 // (not m3_CallV, m3_CallArgv, etc)
 
-#define push_suspend(TYPE, VAL)                                         \
+#define op_push_suspend(TYPE, VAL)                                      \
     do {                                                                \
         if (_mem->runtime->stack_suspend)                               \
         {                                                               \
@@ -133,7 +133,7 @@ d_m3BeginExternC
         }                                                               \
     } while (0)
 
-#define pop_suspend(TYPE)                                       \
+#define op_pop_suspend(TYPE)                                    \
     (_mem->runtime->stack_suspend)                              \
         ? ( *(TYPE*)(                                           \
             _mem->runtime->stack_suspend                        \
@@ -141,7 +141,7 @@ d_m3BeginExternC
             ) )                                                 \
         : (TYPE)POPVAL_SENTINEL
 
-#define peek_suspend(TYPE)                                      \
+#define op_peek_suspend(TYPE)                                   \
     (_mem->runtime->stack_suspend)                              \
         ? ( *(TYPE*)(                                           \
             _mem->runtime->stack_suspend                        \
@@ -151,8 +151,10 @@ d_m3BeginExternC
 
 #define POPVAL_SENTINEL m3_st_Sentinel
 
-#define push_suspend_ptr(TYPE, VAL, BASE)       \
-    push_suspend(TYPE, TO_OFF(TYPE, VAL, BASE))
+#define op_push_suspend_ptr(VAL, BASE)                      \
+    op_push_suspend(void*, TO_OFF(void*, (void*)VAL, BASE))
+
+#define op_pop_suspend_ptr(TYPE)    op_pop_suspend(void*)
 
 typedef enum {
     m3_st_Sentinel = -1,
@@ -611,37 +613,31 @@ d_m3Op  (Call)
 
     u8* base = _mem->runtime->base;
     u8* base_pc = _mem->runtime->base_transient;
-    push_suspend_ptr(pc_t, callPC, base_pc);
-    push_suspend_ptr(m3stack_t, sp, base);
-    push_suspend_ptr(M3MemoryHeader*, _mem, base);
-    push_suspend_ptr(IM3Memory, memory, base);
-    push_suspend_ptr(pc_t, _pc, base_pc);
-    push_suspend_ptr(m3stack_t, _sp, base);
-    push_suspend(m3reg_t, _r0);
-    push_suspend(f64, _fp0);
-    push_suspend(SuspendTag, m3_st_Call);
+    op_push_suspend_ptr(memory, base);
+    op_push_suspend_ptr(_pc, base_pc);
+    op_push_suspend_ptr(_sp, base);
+    op_push_suspend(m3reg_t, _r0);
+    op_push_suspend(f64, _fp0);
+    op_push_suspend(SuspendTag, m3_st_Call);
     // printf("push Call\r\n");
 
     m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
     _mem = memory->mallocated;
 
-    if (r != m3Err_ComputationBlock)
+    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
     {
         u32 edge_1 = _mem->runtime->edge_suspend;
-        SuspendTag t = pop_suspend(SuspendTag);
+        SuspendTag t = op_pop_suspend(SuspendTag);
         if (t != m3_st_Call && t != m3_st_Sentinel)
         {
             return "Call mismatching tags";
         }
         // printf("pop Call\r\n");
-        pop_suspend(f64);
-        pop_suspend(m3reg_t);
-        pop_suspend(m3stack_t);
-        pop_suspend(pc_t);
-        pop_suspend(IM3Memory);
-        pop_suspend(M3MemoryHeader*);
-        pop_suspend(m3stack_t);
-        pop_suspend(pc_t);
+        op_pop_suspend(f64);
+        op_pop_suspend(m3reg_t);
+        op_pop_suspend_ptr(m3stack_t);
+        op_pop_suspend_ptr(pc_t);
+        op_pop_suspend_ptr(IM3Memory);
         u32 edge_2 = _mem->runtime->edge_suspend;
         // printf("pop Call popped: from %d to %d\r\n", edge_1, edge_2);
     }
@@ -685,36 +681,32 @@ d_m3Op  (CallIndirect)
                 {
                     u8* base = _mem->runtime->base;
                     u8* base_pc = _mem->runtime->base_transient;
-                    push_suspend(u32, tableIndex);
-                    push_suspend_ptr(m3stack_t, sp, base);
-                    push_suspend_ptr(M3MemoryHeader*, _mem, base);
-                    push_suspend_ptr(IM3Memory, memory, base);
-                    push_suspend_ptr(pc_t, _pc, base_pc);
-                    push_suspend_ptr(m3stack_t, _sp, base);
-                    push_suspend(m3reg_t, _r0);
-                    push_suspend(f64, _fp0);
-                    push_suspend(SuspendTag, m3_st_Call_indirect);
+
+                    op_push_suspend_ptr(memory, base);
+                    op_push_suspend_ptr(_pc, base_pc);
+                    op_push_suspend_ptr(_sp, base);
+                    op_push_suspend(m3reg_t, _r0);
+                    op_push_suspend(f64, _fp0);
+                    op_push_suspend(SuspendTag, m3_st_Call_indirect);
                     // printf("push Call_indirect\r\n");
 
                     r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
                     _mem = memory->mallocated;
 
-                    if (r != m3Err_ComputationBlock)
+                    if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
                     {
-                        SuspendTag t = pop_suspend(SuspendTag);
+                        SuspendTag t = op_pop_suspend(SuspendTag);
                         if (t != m3_st_Call_indirect && t != m3_st_Sentinel)
                         {
                             return "CallIndirect mismatching tags";
                         }
                         // printf("pop Call_indirect\r\n");
-                        pop_suspend(f64);
-                        pop_suspend(m3reg_t);
-                        pop_suspend(m3stack_t);
-                        pop_suspend(pc_t);
-                        pop_suspend(IM3Memory);
-                        pop_suspend(M3MemoryHeader*);
-                        pop_suspend(m3stack_t);
-                        pop_suspend(u32);
+                        op_pop_suspend(f64);
+                        op_pop_suspend(m3reg_t);
+                        op_pop_suspend_ptr(m3stack_t);
+                        op_pop_suspend_ptr(pc_t);
+                        op_pop_suspend_ptr(IM3Memory);
+                        
                     }
 
                     if (LIKELY(not r))
@@ -791,13 +783,8 @@ d_m3Op  (CallRawFunction)
     runtime->stack = sp;
 
     u8* base = _mem->runtime->base;
-    u8* base_pc = _mem->runtime->base_transient;
-    push_suspend_ptr(u64*, sp, base);
-    push_suspend_ptr(u8*, m3MemData(_mem), base);
-    push_suspend_ptr(IM3Function, ctx.function, base);
-    //  ctx.userdata to be filled during replay
-    push_suspend_ptr(M3RawCall*, call_p, base_pc);
-    push_suspend(SuspendTag, m3_st_CallRaw);
+    op_push_suspend_ptr(stack_backup, base);
+    op_push_suspend(SuspendTag, m3_st_CallRaw);
     // printf("push CallRaw\r\n");
 
     m3ret_t possible_trap = call (runtime, &ctx, sp, m3MemData(_mem));
@@ -818,18 +805,16 @@ d_m3Op  (CallRawFunction)
     }
 #endif
 
-    if (possible_trap != m3Err_ComputationBlock)
+    if (possible_trap != m3Err_ComputationBlock
+        && possible_trap != m3Err_SuspensionError)
     {
-        SuspendTag t = pop_suspend(SuspendTag);
+        SuspendTag t = op_pop_suspend(SuspendTag);
         if (t != m3_st_CallRaw && t != m3_st_Sentinel)
         {
             return "CallRaw mismatching tags";
         }
         // printf("pop CallRaw\r\n");
-        pop_suspend(M3RawCall*);
-        pop_suspend(IM3Function);
-        pop_suspend(u8*);
-        pop_suspend(u64*);
+        op_pop_suspend_ptr(void*);
     }
 
     if (UNLIKELY(possible_trap)) {
@@ -972,15 +957,7 @@ d_m3Op  (Entry)
         trace_rt->callDepth++;
 #endif
 
-        u8* base = _mem->runtime->base;
-        u8* base_pc = _mem->runtime->base_transient;
-        push_suspend_ptr(pc_t, _pc, base_pc);
-        push_suspend_ptr(m3stack_t, _sp, base);
-        push_suspend_ptr(M3MemoryHeader*, _mem, base);
-        push_suspend(m3reg_t, _r0);
-        push_suspend(f64, _fp0);
-        push_suspend_ptr(IM3Memory, memory, base);
-        push_suspend(SuspendTag, m3_st_Entry);
+        op_push_suspend(SuspendTag, m3_st_Entry);
         // printf("push Entry\r\n");
 
         m3ret_t r = nextOpImpl ();
@@ -1003,33 +980,27 @@ d_m3Op  (Entry)
         }
 #endif
 
-        if (r != m3Err_ComputationBlock)
+        if (r != m3Err_ComputationBlock && r != m3Err_SuspensionError)
         {
             SuspendTag t;
             if (r)
             {
-                while (t = peek_suspend(SuspendTag), t == m3_st_Loop)
+                while (t = op_peek_suspend(SuspendTag), t == m3_st_Loop)
                 {
                     // printf("pop Loop\r\n");
-                    pop_suspend(SuspendTag);
-                    pop_suspend(IM3Memory);
-                    pop_suspend(m3stack_t);
-                    pop_suspend(pc_t);
+                    op_pop_suspend(SuspendTag);
+                    op_pop_suspend_ptr(IM3Memory);
+                    op_pop_suspend_ptr(m3stack_t);
+                    op_pop_suspend_ptr(pc_t);
                 }
             }
 
-            t = pop_suspend(SuspendTag);
+            t = op_pop_suspend(SuspendTag);
             if (t != m3_st_Entry && t != m3_st_Sentinel)
             {
                 return "Entry mismatching tags";
             }
             // printf("pop Entry\r\n");
-            pop_suspend(IM3Memory);
-            pop_suspend(f64);
-            pop_suspend(m3reg_t);
-            pop_suspend(M3MemoryHeader*);
-            pop_suspend(m3stack_t);
-            pop_suspend(pc_t);
         }
 
         if (UNLIKELY(r)) {
@@ -1055,11 +1026,11 @@ d_m3Op  (Loop)
 
     u8* base = _mem->runtime->base;
     u8* base_pc = _mem->runtime->base_transient;
-    push_suspend_ptr(pc_t, _pc, base_pc);
-    push_suspend_ptr(m3stack_t, _sp, base);
-    push_suspend_ptr(IM3Memory, memory, base);
+    op_push_suspend_ptr(_pc, base_pc);
+    op_push_suspend_ptr(_sp, base);
+    op_push_suspend_ptr(memory, base);
     // registers are zeros
-    push_suspend(SuspendTag, m3_st_Loop);
+    op_push_suspend(SuspendTag, m3_st_Loop);
     // printf("push Loop\r\n");
 
     do
@@ -1361,15 +1332,15 @@ d_m3Op  (BranchIf_r)
     {
         while (num_loops--)
         {
-            SuspendTag t = pop_suspend(SuspendTag);
+            SuspendTag t = op_pop_suspend(SuspendTag);
             if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
             // printf("pop Loop\r\n");
-            pop_suspend(IM3Memory);
-            pop_suspend(m3stack_t);
-            pop_suspend(pc_t);
+            op_pop_suspend_ptr(IM3Memory);
+            op_pop_suspend_ptr(m3stack_t);
+            op_pop_suspend_ptr(pc_t);
         }
         jumpOp (branch);
     }
@@ -1387,15 +1358,15 @@ d_m3Op  (BranchIf_s)
     {
         while (num_loops--)
         {
-            SuspendTag t = pop_suspend(SuspendTag);
+            SuspendTag t = op_pop_suspend(SuspendTag);
             if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
             // printf("pop Loop\r\n");
-            pop_suspend(IM3Memory);
-            pop_suspend(m3stack_t);
-            pop_suspend(pc_t);
+            op_pop_suspend_ptr(IM3Memory);
+            op_pop_suspend_ptr(m3stack_t);
+            op_pop_suspend_ptr(pc_t);
         }
         jumpOp (branch);
     }
@@ -1454,15 +1425,15 @@ d_m3Op  (ContinueLoopIf)
     {
         while (num_loops--)
         {
-            SuspendTag t = pop_suspend(SuspendTag);
+            SuspendTag t = op_pop_suspend(SuspendTag);
             if (t != m3_st_Loop && t != m3_st_Sentinel)
             {
                 return "Loop mismatching tags";
             }
             // printf("pop Loop\r\n");
-            pop_suspend(IM3Memory);
-            pop_suspend(m3stack_t);
-            pop_suspend(pc_t);
+            op_pop_suspend_ptr(IM3Memory);
+            op_pop_suspend_ptr(m3stack_t);
+            op_pop_suspend_ptr(pc_t);
         }
         return loopId;
     }
@@ -1509,15 +1480,15 @@ d_m3Op  (SuspendPopLoop)
     u32 num_loops = immediate(u32);
     while (num_loops--)
     {
-        SuspendTag t = pop_suspend(SuspendTag);
+        SuspendTag t = op_pop_suspend(SuspendTag);
         if (t != m3_st_Loop && t != m3_st_Sentinel)
         {
             return "Loop mismatching tags";
         }
         // printf("pop Loop\r\n");
-        pop_suspend(IM3Memory);
-        pop_suspend(m3stack_t);
-        pop_suspend(pc_t);
+        op_pop_suspend_ptr(IM3Memory);
+        op_pop_suspend_ptr(m3stack_t);
+        op_pop_suspend_ptr(pc_t);
     }
 
     nextOp ();

--- a/source/m3_function.c
+++ b/source/m3_function.c
@@ -121,6 +121,7 @@ void  Function_Release  (IM3Function i_function)
 void  Function_FreeCompiledCode (IM3Function i_function)
 {
 #   if (d_m3EnableCodePageRefCounting)
+#   error "no codepage refcounting"
     {
         i_function->compiled = NULL;
 

--- a/source/m3_function.c
+++ b/source/m3_function.c
@@ -83,7 +83,7 @@ void FreeImportInfo (M3ImportInfo * i_info)
 
 void  Function_Release  (IM3Function i_function)
 {
-    m3_Free (i_function->constants);
+    m3_FreeTransient (i_function->constants);
 
     for (int i = 0; i < i_function->numNames; i++)
     {

--- a/source/m3_resume.c
+++ b/source/m3_resume.c
@@ -45,7 +45,6 @@ m3_Resume(IM3Runtime runtime)
                     r_pop_suspend(m3reg_t);
                     r_pop_suspend_ptr(runtime, base);
                     r_pop_suspend_ptr(runtime, base_pc);
-                    r_pop_suspend_ptr(runtime, base);
                 }
                 // pop the frame, treat the call, "return" the result
                 // to the next frame
@@ -60,9 +59,8 @@ m3_Resume(IM3Runtime runtime)
                     m3reg_t _r0 = r_pop_suspend(m3reg_t);
                     m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
                     pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
-                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
 
-                    M3MemoryHeader* _mem = memory->mallocated;
+                    M3MemoryHeader* _mem = runtime->memory.mallocated;
                     result = nextOpImpl();
                 }
                 break;
@@ -79,7 +77,6 @@ m3_Resume(IM3Runtime runtime)
                     r_pop_suspend(m3reg_t);
                     r_pop_suspend_ptr(runtime, base);
                     r_pop_suspend_ptr(runtime, base_pc);
-                    r_pop_suspend_ptr(runtime, base);
                 }
                 else
                 {
@@ -91,9 +88,8 @@ m3_Resume(IM3Runtime runtime)
                     m3reg_t _r0 = r_pop_suspend(m3reg_t);
                     m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
                     pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
-                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
                     
-                    M3MemoryHeader* _mem = memory->mallocated;
+                    M3MemoryHeader* _mem = runtime->memory.mallocated;
                     result = nextOpImpl();
                 }
                 break;
@@ -110,11 +106,6 @@ m3_Resume(IM3Runtime runtime)
                 runtime->stack = stack_backup;
                 break;
             }
-            case m3_st_Entry:
-            {
-                r_pop_suspend(SuspendTag);
-                break;
-            }
             case m3_st_Loop:
             {
                 // non empty result in case of op_Loop
@@ -124,20 +115,40 @@ m3_Resume(IM3Runtime runtime)
                 u8* base_pc = runtime->base_transient;
 
                 r_pop_suspend(SuspendTag);
-                IM3Memory memory = r_pop_suspend_ptr(runtime, base);
                 m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
                 pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
 
-                M3MemoryHeader* _mem = memory->mallocated;
+                M3MemoryHeader* _mem = runtime->memory.mallocated;
                 m3ret_t r = result;
-
-                // while instead of do..while because we might
-                // already be done with the loop
+                
+                //  we might get blocked again in the loop, so restore the
+                //  frame if reenter
                 //
-                while (r == _pc)
+                if (r == _pc)
                 {
-                    r = ((IM3Operation)(*_pc))(_pc + 1, _sp, _mem, 0, 0);
-                    _mem = memory->mallocated;
+                    r_push_suspend_ptr(_pc, base_pc);
+                    r_push_suspend_ptr(_sp, base);
+                    r_push_suspend(SuspendTag, m3_st_Loop);
+                    
+                    do
+                    {
+                        r = ((IM3Operation)(*_pc))(_pc + 1, _sp, _mem, 0, 0);
+                        M3MemoryHeader* _mem = runtime->memory.mallocated;
+                    }
+                    while (r == _pc);
+                    
+
+                    //  optz: we might know that we are done with the loop,
+                    //  pop the frame immediately if so
+                    //
+                    result = r;
+                    if (result != m3Err_ComputationBlock 
+                        && result != m3Err_SuspensionError)
+                    {
+                        r_pop_suspend(SuspendTag);
+                        r_pop_suspend_ptr(runtime, base);
+                        r_pop_suspend_ptr(runtime, base_pc);
+                    }
                 }
 
                 result = r;

--- a/source/m3_resume.c
+++ b/source/m3_resume.c
@@ -1,0 +1,217 @@
+#include "m3_env.h"
+
+#include "m3_resume.h"
+
+M3Result
+m3_Resume(IM3Runtime runtime)
+{
+    if (!runtime->stack_suspend)
+    {
+        return m3Err_none;
+    }
+    
+    M3Result result = m3Err_none;
+    
+    while (runtime->edge_suspend)
+    {
+        SuspendTag t = r_peek_suspend(SuspendTag);
+        switch (t)
+        {
+            default:
+            {
+                return m3Err_SuspensionError;
+            }
+            case m3_st_External:
+            {
+                result = runtime->resume_external(result, runtime);
+                break;
+            }
+            case m3_st_Call:
+            {
+                // case of non-blocking unsuccessful result:
+                // just pop the frame and go on, "returning" the result
+                // to the next frame
+                //
+                if (result
+                    && result != m3Err_ComputationBlock
+                    && result != m3Err_SuspensionError)
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    r_pop_suspend(f64);
+                    r_pop_suspend(m3reg_t);
+                    r_pop_suspend_ptr(runtime, base);
+                    r_pop_suspend_ptr(runtime, base_pc);
+                    r_pop_suspend_ptr(runtime, base);
+                }
+                // either new block or suspension error:
+                // leave everything as is, return
+                //
+                else if (result)
+                {
+                    return result;
+                }
+                // pop the frame, treat the call, "return" the result
+                // to the next frame
+                //
+                else
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+                    
+                    r_pop_suspend(SuspendTag);
+                    f64 _fp0 = r_pop_suspend(f64);
+                    m3reg_t _r0 = r_pop_suspend(m3reg_t);
+                    m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
+                    pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
+                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
+
+                    M3MemoryHeader* _mem = memory->mallocated;
+                    result = nextOpImpl();
+                }
+                break;
+            }
+            case m3_st_Call_indirect:
+            {
+                if (result
+                    && result != m3Err_ComputationBlock
+                    && result != m3Err_SuspensionError)
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    r_pop_suspend(f64);
+                    r_pop_suspend(m3reg_t);
+                    r_pop_suspend_ptr(runtime, base);
+                    r_pop_suspend_ptr(runtime, base_pc);
+                    r_pop_suspend_ptr(runtime, base);
+                }
+                else if (result)
+                {
+                    return result;
+                }
+                else
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    f64 _fp0 = r_pop_suspend(f64);
+                    m3reg_t _r0 = r_pop_suspend(m3reg_t);
+                    m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
+                    pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
+                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
+                    
+                    M3MemoryHeader* _mem = memory->mallocated;
+                    result = nextOpImpl();
+                }
+                break;
+            }
+            case m3_st_CallRaw:
+            {
+                if (result != m3Err_ComputationBlock
+                    && result != m3Err_SuspensionError)
+                {
+                    // we always restore backed up stack if we are not blocked
+                    //
+                    r_pop_suspend(SuspendTag);
+                    void* stack_backup = r_pop_suspend_ptr(
+                        runtime,
+                        runtime->base
+                    );
+                    runtime->stack = stack_backup;
+                }
+                else
+                {
+                    return result;
+                }
+                break;
+            }
+            case m3_st_Entry:
+            {
+                // trivial frame, nothing to handle
+                //
+                if (result != m3Err_ComputationBlock
+                    && result != m3Err_SuspensionError)
+                {
+                    r_pop_suspend(SuspendTag);
+                }
+                else
+                {
+                    return result;
+                }
+                break;
+            }
+            case m3_st_Loop:
+            {
+                if (result == m3Err_ComputationBlock
+                    || result == m3Err_SuspensionError)
+                {
+                    return result;
+                }
+                else
+                {
+                    // non empty result in case of op_Loop
+                    // may also be loop's label
+                    //
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
+                    m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
+                    pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
+
+                    M3MemoryHeader* _mem = memory->mallocated;
+                    m3ret_t r = result;
+
+                    // while instead of do..while because we might
+                    // already be done with the loop
+                    //
+                    while (r == _pc)
+                    {
+                        r = ((IM3Operation)(*_pc))(_pc + 1, _sp, _mem, 0, 0);
+                        _mem = memory->mallocated;
+                    }
+
+                    result = r;
+                }
+                break;
+            }
+            case m3_st_m3_Call:
+            {
+                if (result
+                    && result != m3Err_ComputationBlock
+                    && result != m3Err_SuspensionError)
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    r_pop_suspend_ptr(runtime, base);
+
+                    runtime->lastCalled = NULL;
+                }
+                else if (result)
+                {
+                    return result;
+                }
+                else
+                {
+                    u8* base = runtime->base;
+                    u8* base_pc = runtime->base_transient;
+
+                    r_pop_suspend(SuspendTag);
+                    IM3Function i_function = r_pop_suspend_ptr(runtime, base);
+                    runtime->lastCalled = i_function;
+                }
+                break;
+            }
+        }
+    }
+
+    return result;
+}

--- a/source/m3_resume.c
+++ b/source/m3_resume.c
@@ -12,7 +12,10 @@ m3_Resume(IM3Runtime runtime)
     
     M3Result result = m3Err_none;
     
-    while (runtime->edge_suspend)
+    while (runtime->edge_suspend
+        && result != m3Err_ComputationBlock
+        && result != m3Err_SuspensionError
+    )
     {
         SuspendTag t = r_peek_suspend(SuspendTag);
         switch (t)
@@ -32,9 +35,7 @@ m3_Resume(IM3Runtime runtime)
                 // just pop the frame and go on, "returning" the result
                 // to the next frame
                 //
-                if (result
-                    && result != m3Err_ComputationBlock
-                    && result != m3Err_SuspensionError)
+                if (result)
                 {
                     u8* base = runtime->base;
                     u8* base_pc = runtime->base_transient;
@@ -45,13 +46,6 @@ m3_Resume(IM3Runtime runtime)
                     r_pop_suspend_ptr(runtime, base);
                     r_pop_suspend_ptr(runtime, base_pc);
                     r_pop_suspend_ptr(runtime, base);
-                }
-                // either new block or suspension error:
-                // leave everything as is, return
-                //
-                else if (result)
-                {
-                    return result;
                 }
                 // pop the frame, treat the call, "return" the result
                 // to the next frame
@@ -75,9 +69,7 @@ m3_Resume(IM3Runtime runtime)
             }
             case m3_st_Call_indirect:
             {
-                if (result
-                    && result != m3Err_ComputationBlock
-                    && result != m3Err_SuspensionError)
+                if (result)
                 {
                     u8* base = runtime->base;
                     u8* base_pc = runtime->base_transient;
@@ -88,10 +80,6 @@ m3_Resume(IM3Runtime runtime)
                     r_pop_suspend_ptr(runtime, base);
                     r_pop_suspend_ptr(runtime, base_pc);
                     r_pop_suspend_ptr(runtime, base);
-                }
-                else if (result)
-                {
-                    return result;
                 }
                 else
                 {
@@ -112,80 +100,52 @@ m3_Resume(IM3Runtime runtime)
             }
             case m3_st_CallRaw:
             {
-                if (result != m3Err_ComputationBlock
-                    && result != m3Err_SuspensionError)
-                {
-                    // we always restore backed up stack if we are not blocked
-                    //
-                    r_pop_suspend(SuspendTag);
-                    void* stack_backup = r_pop_suspend_ptr(
-                        runtime,
-                        runtime->base
-                    );
-                    runtime->stack = stack_backup;
-                }
-                else
-                {
-                    return result;
-                }
+                // we always restore backed up stack if we are not blocked
+                //
+                r_pop_suspend(SuspendTag);
+                void* stack_backup = r_pop_suspend_ptr(
+                    runtime,
+                    runtime->base
+                );
+                runtime->stack = stack_backup;
                 break;
             }
             case m3_st_Entry:
             {
-                // trivial frame, nothing to handle
-                //
-                if (result != m3Err_ComputationBlock
-                    && result != m3Err_SuspensionError)
-                {
-                    r_pop_suspend(SuspendTag);
-                }
-                else
-                {
-                    return result;
-                }
+                r_pop_suspend(SuspendTag);
                 break;
             }
             case m3_st_Loop:
             {
-                if (result == m3Err_ComputationBlock
-                    || result == m3Err_SuspensionError)
+                // non empty result in case of op_Loop
+                // may also be loop's label
+                //
+                u8* base = runtime->base;
+                u8* base_pc = runtime->base_transient;
+
+                r_pop_suspend(SuspendTag);
+                IM3Memory memory = r_pop_suspend_ptr(runtime, base);
+                m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
+                pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
+
+                M3MemoryHeader* _mem = memory->mallocated;
+                m3ret_t r = result;
+
+                // while instead of do..while because we might
+                // already be done with the loop
+                //
+                while (r == _pc)
                 {
-                    return result;
+                    r = ((IM3Operation)(*_pc))(_pc + 1, _sp, _mem, 0, 0);
+                    _mem = memory->mallocated;
                 }
-                else
-                {
-                    // non empty result in case of op_Loop
-                    // may also be loop's label
-                    //
-                    u8* base = runtime->base;
-                    u8* base_pc = runtime->base_transient;
 
-                    r_pop_suspend(SuspendTag);
-                    IM3Memory memory = r_pop_suspend_ptr(runtime, base);
-                    m3stack_t _sp = r_pop_suspend_ptr(runtime, base);
-                    pc_t _pc = r_pop_suspend_ptr(runtime, base_pc);
-
-                    M3MemoryHeader* _mem = memory->mallocated;
-                    m3ret_t r = result;
-
-                    // while instead of do..while because we might
-                    // already be done with the loop
-                    //
-                    while (r == _pc)
-                    {
-                        r = ((IM3Operation)(*_pc))(_pc + 1, _sp, _mem, 0, 0);
-                        _mem = memory->mallocated;
-                    }
-
-                    result = r;
-                }
+                result = r;
                 break;
             }
             case m3_st_m3_Call:
             {
-                if (result
-                    && result != m3Err_ComputationBlock
-                    && result != m3Err_SuspensionError)
+                if (result)
                 {
                     u8* base = runtime->base;
                     u8* base_pc = runtime->base_transient;
@@ -194,10 +154,6 @@ m3_Resume(IM3Runtime runtime)
                     r_pop_suspend_ptr(runtime, base);
 
                     runtime->lastCalled = NULL;
-                }
-                else if (result)
-                {
-                    return result;
                 }
                 else
                 {

--- a/source/m3_resume.h
+++ b/source/m3_resume.h
@@ -4,7 +4,6 @@
 #include "wasm3.h"
 #include "m3_core.h"
 #include "m3_exec.h"
-#include "m3_exception.h"
 #include "m3_rewrite.h"
 
 #define r_pop_suspend(TYPE)                             \
@@ -22,5 +21,7 @@ r_pop_suspend_ptr(IM3Runtime runtime, u8* base)
     void* offset = r_pop_suspend(void*);
     return TO_PTR(void*, offset, base);
 }
+
+M3Result m3_Resume(IM3Runtime runtime);
 
 #endif // m3_resume_h

--- a/source/m3_resume.h
+++ b/source/m3_resume.h
@@ -22,6 +22,23 @@ r_pop_suspend_ptr(IM3Runtime runtime, u8* base)
     return TO_PTR(void*, offset, base);
 }
 
+#define r_push_suspend(TYPE, VAL)                                 \
+    do {                                                          \
+        if (runtime->stack_suspend)                               \
+        {                                                         \
+            u32 edge = runtime->edge_suspend;                     \
+            if (edge + slots_of(TYPE) > runtime->size_suspend)    \
+            {                                                     \
+                return m3Err_trapStackOverflow;                   \
+            }                                                     \
+            *(TYPE*)(runtime->stack_suspend + edge) = (VAL);      \
+            runtime->edge_suspend += slots_of(TYPE);              \
+        }                                                         \
+    } while (0)
+
+#define r_push_suspend_ptr(VAL, BASE)                             \
+    r_push_suspend(void*, TO_OFF(void*, (void*)VAL, BASE))
+
 M3Result m3_Resume(IM3Runtime runtime);
 
 #endif // m3_resume_h

--- a/source/m3_resume.h
+++ b/source/m3_resume.h
@@ -1,0 +1,26 @@
+#ifndef m3_resume_h
+#define m3_resume_h
+
+#include "wasm3.h"
+#include "m3_core.h"
+#include "m3_exec.h"
+#include "m3_exception.h"
+#include "m3_rewrite.h"
+
+#define r_pop_suspend(TYPE)                             \
+    ( *(TYPE*)(                                         \
+            runtime->stack_suspend                      \
+            + (runtime->edge_suspend -= slots_of(TYPE)) \
+            ) )
+            
+#define r_peek_suspend(TYPE)                                                    \
+  (*(TYPE*)(runtime->stack_suspend + (runtime->edge_suspend - slots_of(TYPE))))  
+
+static inline void*
+r_pop_suspend_ptr(IM3Runtime runtime, u8* base)
+{
+    void* offset = r_pop_suspend(void*);
+    return TO_PTR(void*, offset, base);
+}
+
+#endif // m3_resume_h

--- a/source/m3_rewrite.c
+++ b/source/m3_rewrite.c
@@ -35,7 +35,7 @@ RewritePointersFunction(IM3Function f, u8* base, bool is_store)
     REWRITE(IM3FuncType, f->funcType, base, is_store);
     NULLIFY_STORE(f->compiled, is_store);
     nullify_codepagerefs;
-    REWRITE(void*, f->constants, base, is_store);
+    NULLIFY_STORE(f->constants, is_store);
 }
 
 static void
@@ -66,17 +66,9 @@ RewritePointersFuncType(IM3FuncType t, u8* base, bool is_store)
 }
 
 static void
-RewritePointersMemoryHeader(M3MemoryHeader* h, u8* base, bool is_store)
-{
-    REWRITE(IM3Runtime, h->runtime, base, is_store);
-    REWRITE(void*, h->maxStack, base, is_store);
-}
-
-static void
 RewritePointersMemory(M3Memory* m, u8* base, bool is_store)
 {
-    REWRITE_F(M3MemoryHeader *, m->mallocated, base, is_store,
-        RewritePointersMemoryHeader);
+    NULLIFY_STORE(m->mallocated, is_store);
 }
 
 

--- a/source/m3_rewrite.c
+++ b/source/m3_rewrite.c
@@ -75,29 +75,8 @@ RewritePointersMemoryHeader(M3MemoryHeader* h, u8* base, bool is_store)
 static void
 RewritePointersMemory(M3Memory* m, u8* base, bool is_store)
 {
-    // REWRITE_F(M3MemoryHeader *, m->mallocated, base, is_store,
-    //     RewritePointersMemoryHeader);
-    do {
-        if (is_store)
-        {
-            M3MemoryHeader * off = TO_OFF(M3MemoryHeader *, m->mallocated, base);
-            if (off != (m->mallocated))
-            {
-                M3MemoryHeader * ptr_tmp = m->mallocated;
-                m->mallocated = off;
-                RewritePointersMemoryHeader(ptr_tmp, base, is_store);
-            }
-        }
-        else
-        {
-            M3MemoryHeader * ptr = TO_PTR(M3MemoryHeader *, m->mallocated, base);
-            if (ptr != (m->mallocated))
-            {
-                m->mallocated = ptr;
-                RewritePointersMemoryHeader(ptr, base, is_store);
-            }
-        }
-    } while (0);
+    REWRITE_F(M3MemoryHeader *, m->mallocated, base, is_store,
+        RewritePointersMemoryHeader);
 }
 
 
@@ -218,30 +197,8 @@ m3_RewritePointersRuntime(IM3Runtime r, u8* base, bool is_store)
         /**/
         memset(&r->error, 0, sizeof(r->error));
     }
-    // REWRITE_F(IM3Environment, r->environment, base, is_store,
-    //     RewritePointersEnvironment);
-    do {
-        if (is_store)
-        {
-            IM3Environment off = TO_OFF(IM3Environment, r->environment, base);
-            if (off != (r->environment))
-            {
-                IM3Environment ptr_tmp = r->environment;
-                r->environment = off;
-                RewritePointersEnvironment(ptr_tmp, base, is_store);
-            }
-        }
-        else
-        {
-            IM3Environment ptr = NULL;
-            ptr = TO_PTR(IM3Environment, r->environment, base);
-            if (ptr != (r->environment))
-            {
-                r->environment = ptr;
-                RewritePointersEnvironment(ptr, base, is_store);
-            }
-        }
-    } while (0);
+    REWRITE_F(IM3Environment, r->environment, base, is_store,
+        RewritePointersEnvironment);
     /* Code pages are allocated transiently */
     NULLIFY_STORE(r->pagesOpen, is_store);
     NULLIFY_STORE(r->pagesFull, is_store);
@@ -255,6 +212,5 @@ m3_RewritePointersRuntime(IM3Runtime r, u8* base, bool is_store)
     REWRITE(IM3Function, r->lastCalled, base, is_store);
     /* user is responsible for his data */
     NULLIFY_STORE(r->userdata, is_store);
-    NULLIFY_STORE(r->userdata_import, is_store);
     RewritePointersMemory(&r->memory, base, is_store);
 }

--- a/source/m3_rewrite.c
+++ b/source/m3_rewrite.c
@@ -10,204 +10,251 @@
 #   define nullify_codepagerefs do {} while (0)
 #endif
 
-#define RewritePointersFunction(STORE_OR_LOAD, IS_STORE)                        \
-    static void                                                                 \
-    RewritePointersFunction##STORE_OR_LOAD(IM3Function f, u8* base)             \
-    {                                                                           \
-        REWRITE(IM3Module, f->module, base, IS_STORE);                          \
-        REWRITE(char*, f->import.moduleUtf8, base, IS_STORE);                   \
-        REWRITE(char*, f->import.fieldUtf8, base, IS_STORE);                    \
-        REWRITE(bytes_t, f->wasm, base, IS_STORE);                              \
-        REWRITE(bytes_t, f->wasmEnd, base, IS_STORE);                           \
-        for (u32 i = 0; i < f->numNames; i++)                                   \
-        {                                                                       \
-            REWRITE(cstr_t, f->names[i], base, IS_STORE);                       \
-        }                                                                       \
-        REWRITE(cstr_t*, f->names, base, IS_STORE);                             \
-        REWRITE(IM3FuncType, f->funcType, base, IS_STORE);                      \
-        NULLIFY_STORE(f->compiled, IS_STORE);                                   \
-        nullify_codepagerefs;                                                   \
-        REWRITE(void*, f->constants, base, IS_STORE);                           \
+static void
+RewritePointersFunction(IM3Function f, u8* base, bool is_store)
+{
+    REWRITE(IM3Module, f->module, base, is_store);
+    REWRITE(char*, f->import.moduleUtf8, base, is_store);
+    REWRITE(char*, f->import.fieldUtf8, base, is_store);
+    REWRITE(bytes_t, f->wasm, base, is_store);
+    REWRITE(bytes_t, f->wasmEnd, base, is_store);
+
+    if (!is_store)
+    {
+        REWRITE(cstr_t*, f->names, base, is_store);
     }
-RewritePointersFunction(Store, 1)
-RewritePointersFunction(Load, 0)
-
-
-#define RewritePointersDataSegment(STORE_OR_LOAD, IS_STORE)                     \
-    static void                                                                 \
-    RewritePointersDataSegment##STORE_OR_LOAD(M3DataSegment* d, u8* base)       \
-    {                                                                           \
-        REWRITE(u8*, d->initExpr, base, IS_STORE);                              \
-        REWRITE(u8*, d->data, base, IS_STORE);                                  \
+    for (u32 i = 0; i < f->numNames; i++)
+    {
+        REWRITE(cstr_t, f->names[i], base, is_store);
     }
-RewritePointersDataSegment(Store, 1)
-RewritePointersDataSegment(Load, 0)
-
-
-#define RewritePointersGlobal(STORE_OR_LOAD, IS_STORE)                          \
-    static void                                                                 \
-    RewritePointersGlobal##STORE_OR_LOAD(IM3Global g, u8* base)                 \
-    {                                                                           \
-        REWRITE(char*, g->import.fieldUtf8, base, IS_STORE);                    \
-        REWRITE(char*, g->import.moduleUtf8, base, IS_STORE);                   \
-        REWRITE(cstr_t, g->name, base, IS_STORE);                               \
-        REWRITE(bytes_t, g->initExpr, base, IS_STORE);                          \
+    if (is_store)
+    {
+        REWRITE(cstr_t*, f->names, base, is_store);
     }
-RewritePointersGlobal(Store, 1)
-RewritePointersGlobal(Load, 0)
+
+    REWRITE(IM3FuncType, f->funcType, base, is_store);
+    NULLIFY_STORE(f->compiled, is_store);
+    nullify_codepagerefs;
+    REWRITE(void*, f->constants, base, is_store);
+}
+
+static void
+RewritePointersDataSegment(M3DataSegment* d, u8* base, bool is_store)
+{
+    REWRITE(u8*, d->initExpr, base, is_store);
+    REWRITE(u8*, d->data, base, is_store);
+}
 
 
+static void
+RewritePointersGlobal(IM3Global g, u8* base, bool is_store)
+{
+    REWRITE(char*, g->import.fieldUtf8, base, is_store);
+    REWRITE(char*, g->import.moduleUtf8, base, is_store);
+    REWRITE(cstr_t, g->name, base, is_store);
+    REWRITE(bytes_t, g->initExpr, base, is_store);
+}
 
-#define RewritePointersFuncType(STORE_OR_LOAD, IS_STORE)                        \
-    static void                                                                 \
-    RewritePointersFuncType##STORE_OR_LOAD(IM3FuncType t, u8* base)             \
-    {                                                                           \
-        REWRITE_F(IM3FuncType,                                                  \
-            t->next,                                                            \
-            base,                                                               \
-            IS_STORE,                                                           \
-            RewritePointersFuncType##STORE_OR_LOAD);                            \
+static void
+RewritePointersFuncType(IM3FuncType t, u8* base, bool is_store)
+{
+    REWRITE_F(IM3FuncType,
+        t->next,
+        base,
+        is_store,
+        RewritePointersFuncType);
+}
+
+static void
+RewritePointersMemoryHeader(M3MemoryHeader* h, u8* base, bool is_store)
+{
+    REWRITE(IM3Runtime, h->runtime, base, is_store);
+    REWRITE(void*, h->maxStack, base, is_store);
+}
+
+static void
+RewritePointersMemory(M3Memory* m, u8* base, bool is_store)
+{
+    // REWRITE_F(M3MemoryHeader *, m->mallocated, base, is_store,
+    //     RewritePointersMemoryHeader);
+    do {
+        if (is_store)
+        {
+            M3MemoryHeader * off = TO_OFF(M3MemoryHeader *, m->mallocated, base);
+            if (off != (m->mallocated))
+            {
+                M3MemoryHeader * ptr_tmp = m->mallocated;
+                m->mallocated = off;
+                RewritePointersMemoryHeader(ptr_tmp, base, is_store);
+            }
+        }
+        else
+        {
+            M3MemoryHeader * ptr = TO_PTR(M3MemoryHeader *, m->mallocated, base);
+            if (ptr != (m->mallocated))
+            {
+                m->mallocated = ptr;
+                RewritePointersMemoryHeader(ptr, base, is_store);
+            }
+        }
+    } while (0);
+}
+
+
+static void
+RewritePointersModule(IM3Module m, u8* base, bool is_store)
+{
+    /* do not enter runtime, environment, they called us */
+    REWRITE(IM3Runtime, m->runtime, base, is_store);
+    REWRITE(IM3Environment, m->environment, base, is_store);
+    REWRITE(bytes_t, m->wasmStart, base, is_store);
+    REWRITE(bytes_t, m->wasmEnd, base, is_store);
+    REWRITE(cstr_t, m->name, base, is_store);
+
+    if (!is_store)
+    {
+        REWRITE(IM3FuncType*, m->funcTypes, base, is_store);
     }
-RewritePointersFuncType(Store, 1)
-RewritePointersFuncType(Load, 0)
-
-
-#define RewritePointersMemoryHeader(STORE_OR_LOAD, IS_STORE)                    \
-    static void                                                                 \
-    RewritePointersMemoryHeader##STORE_OR_LOAD(M3MemoryHeader* h, u8* base)     \
-    {                                                                           \
-        REWRITE(IM3Runtime, h->runtime, base, IS_STORE);                        \
-        REWRITE(void*, h->maxStack, base, IS_STORE);                            \
+    for (u32 i = 0; i < m->numFuncTypes; i++)
+    {
+        /* do not enter funcTypes, they are handled in environment */
+        REWRITE(IM3FuncType, m->funcTypes[i], base, is_store);
     }
-RewritePointersMemoryHeader(Store, 1)
-RewritePointersMemoryHeader(Load, 0)
-
-
-#define RewritePointersMemory(STORE_OR_LOAD, IS_STORE)                          \
-    static void                                                                 \
-    RewritePointersMemory##STORE_OR_LOAD(M3Memory* m, u8* base)                 \
-    {                                                                           \
-        REWRITE_F(M3MemoryHeader *, m->mallocated, base, IS_STORE,              \
-            RewritePointersMemoryHeader##STORE_OR_LOAD);                        \
+    if (is_store)
+    {
+        REWRITE(IM3FuncType*, m->funcTypes, base, is_store);
     }
-RewritePointersMemory(Store, 1)
-RewritePointersMemory(Load, 0)
 
-
-#define RewritePointersModule(STORE_OR_LOAD, IS_STORE)                          \
-    static void                                                                 \
-    RewritePointersModule##STORE_OR_LOAD(IM3Module m, u8* base)                 \
-    {                                                                           \
-        /* do not enter runtime, environment, they called us */                 \
-        REWRITE(IM3Runtime, m->runtime, base, IS_STORE);                        \
-        REWRITE(IM3Environment, m->environment, base, IS_STORE);                \
-        REWRITE(bytes_t, m->wasmStart, base, IS_STORE);                         \
-        REWRITE(bytes_t, m->wasmEnd, base, IS_STORE);                           \
-        REWRITE(cstr_t, m->name, base, IS_STORE);                               \
-        for (u32 i = 0; i < m->numFuncTypes; i++)                               \
-        {                                                                       \
-            /* do not enter funcTypes, they are handled in environment */       \
-            REWRITE(IM3FuncType, m->funcTypes[i], base, IS_STORE);              \
-        }                                                                       \
-        REWRITE(IM3FuncType*, m->funcTypes, base, IS_STORE);                    \
-        for (u32 i = 0; i < m->numFunctions; i++)                               \
-        {                                                                       \
-            RewritePointersFunction##STORE_OR_LOAD(&m->functions[i],base);      \
-        }                                                                       \
-        REWRITE(M3Function *, m->functions, base, IS_STORE);                    \
-        for (u32 i = 0; i < m->numDataSegments; i++)                            \
-        {                                                                       \
-            RewritePointersDataSegment##STORE_OR_LOAD(                          \
-                &m->dataSegments[i],                                            \
-                base                                                            \
-            );                                                                  \
-        }                                                                       \
-        REWRITE(M3DataSegment *, m->dataSegments, base, IS_STORE);              \
-        for (u32 i = 0; i < m->numGlobals; i++)                                 \
-        {                                                                       \
-            RewritePointersGlobal##STORE_OR_LOAD(&m->globals[i], base);         \
-        }                                                                       \
-        REWRITE(M3Global *, m->globals, base, IS_STORE);                        \
-        REWRITE(bytes_t, m->elementSection, base, IS_STORE);                    \
-        REWRITE(bytes_t, m->elementSectionEnd, base, IS_STORE);                 \
-        for (u32 i = 0; i < m->table0Size; i++)                                 \
-        {                                                                       \
-            REWRITE(IM3Function, m->table0[i], base, IS_STORE);                 \
-        }                                                                       \
-        REWRITE(IM3Function*, m->table0, base, IS_STORE);                       \
-        REWRITE_F(IM3Module,                                                    \
-            m->next,                                                            \
-            base,                                                               \
-            IS_STORE,                                                           \
-            RewritePointersModule##STORE_OR_LOAD);                              \
+    if (!is_store)
+    {
+        REWRITE(M3Function *, m->functions, base, is_store);
     }
-RewritePointersModule(Store, 1)
-RewritePointersModule(Load, 0)
-
-
-#define RewritePointersEnvironment(STORE_OR_LOAD, IS_STORE)                     \
-    static void                                                                 \
-    RewritePointersEnvironment##STORE_OR_LOAD(IM3Environment e, u8* base)       \
-    {                                                                           \
-        REWRITE_F(IM3FuncType, e->funcTypes, base, IS_STORE,                    \
-            RewritePointersFuncType##STORE_OR_LOAD);                            \
-        for (u32 i = 0; i < c_m3Type_unknown; i++)                              \
-        {                                                                       \
-            /* retFuncTypes "point" to funcTypes, do not enter */               \
-            REWRITE(IM3FuncType, e->retFuncTypes[i], base, IS_STORE);           \
-        }                                                                       \
-            NULLIFY_STORE(e->pagesReleased, IS_STORE);                          \
+    for (u32 i = 0; i < m->numFunctions; i++)
+    {
+        RewritePointersFunction(&m->functions[i],base, is_store);
     }
-RewritePointersEnvironment(Store, 1)
-RewritePointersEnvironment(Load, 0)
-
-
-#define RewritePointersRuntime(STORE_OR_LOAD, IS_STORE)                         \
-    static void                                                                 \
-    RewritePointersRuntime##STORE_OR_LOAD(IM3Runtime r, u8* base)               \
-    {                                                                           \
-        if (IS_STORE)                                                           \
-        {                                                                       \
-            /* reset compilation, code pages must be freed           */         \
-            /* this is because code pages contain function pointers, */         \
-            /* and preserving them does not seem feasible            */         \
-            /**/                                                                \
-            memset(&r->compilation, 0, sizeof(r->compilation));                 \
-            /* ErrorInfo contains pointers to static storage */                 \
-            /**/                                                                \
-            memset(&r->error, 0, sizeof(r->error));                             \
-        }                                                                       \
-        REWRITE_F(IM3Environment, r->environment, base, IS_STORE,               \
-            RewritePointersEnvironment##STORE_OR_LOAD);                         \
-        /* Code pages are allocated transiently */                              \
-        NULLIFY_STORE(r->pagesOpen, IS_STORE);                                  \
-        NULLIFY_STORE(r->pagesFull, IS_STORE);                                  \
-        REWRITE_F(IM3Module, r->modules, base, IS_STORE,                        \
-            RewritePointersModule##STORE_OR_LOAD);                              \
-        REWRITE(void*, r->stack, base, IS_STORE);                               \
-        REWRITE(m3slot_t*, r->stack_suspend, base, IS_STORE);                   \
-        NULLIFY_STORE(r->base, IS_STORE);                                       \
-        NULLIFY_STORE(r->base_transient, IS_STORE);                             \
-        /* don't enter runtime->lastCalled, we will get there eventually */     \
-        REWRITE(IM3Function, r->lastCalled, base, IS_STORE);                    \
-        /* user is responsible for his data */                                  \
-        NULLIFY_STORE(r->userdata, IS_STORE);                                   \
-        NULLIFY_STORE(r->userdata_import, IS_STORE);                            \
-        RewritePointersMemory##STORE_OR_LOAD(&r->memory, base);                 \
+    if (is_store)
+    {
+        REWRITE(M3Function *, m->functions, base, is_store);
     }
-RewritePointersRuntime(Store, 1)
-RewritePointersRuntime(Load, 0)
+    
+    if (!is_store)
+    {
+        REWRITE(M3DataSegment *, m->dataSegments, base, is_store);
+    }
+    for (u32 i = 0; i < m->numDataSegments; i++)
+    {
+        RewritePointersDataSegment(
+            &m->dataSegments[i],
+            base,
+            is_store
+        );
+    }
+    if (is_store)
+    {
+        REWRITE(M3DataSegment *, m->dataSegments, base, is_store);
+    }
 
+    if (!is_store)
+    {
+        REWRITE(M3Global *, m->globals, base, is_store);
+    }
+    for (u32 i = 0; i < m->numGlobals; i++)
+    {
+        RewritePointersGlobal(&m->globals[i], base, is_store);
+    }
+    if (is_store)
+    {
+        REWRITE(M3Global *, m->globals, base, is_store);
+    }
+
+    REWRITE(bytes_t, m->elementSection, base, is_store);
+    REWRITE(bytes_t, m->elementSectionEnd, base, is_store);
+
+    if (!is_store)
+    {
+        REWRITE(IM3Function*, m->table0, base, is_store);
+    }
+    for (u32 i = 0; i < m->table0Size; i++)
+    {
+        REWRITE(IM3Function, m->table0[i], base, is_store);
+    }
+    if (is_store)
+    {
+        REWRITE(IM3Function*, m->table0, base, is_store);
+    }
+
+    REWRITE_F(IM3Module,
+        m->next,
+        base,
+        is_store,
+        RewritePointersModule);
+}
+
+static void
+RewritePointersEnvironment(IM3Environment e, u8* base, bool is_store)
+{
+    REWRITE_F(IM3FuncType, e->funcTypes, base, is_store,
+        RewritePointersFuncType);
+    for (u32 i = 0; i < c_m3Type_unknown; i++)
+    {
+        /* retFuncTypes "point" to funcTypes, do not enter */
+        REWRITE(IM3FuncType, e->retFuncTypes[i], base, is_store);
+    }
+        NULLIFY_STORE(e->pagesReleased, is_store);
+}
 
 void
 m3_RewritePointersRuntime(IM3Runtime r, u8* base, bool is_store)
 {
     if (is_store)
     {
-        RewritePointersRuntimeStore(r, base);
+        /* reset compilation, code pages must be freed           */
+        /* this is because code pages contain function pointers, */
+        /* and preserving them does not seem feasible            */
+        /**/
+        memset(&r->compilation, 0, sizeof(r->compilation));
+        /* ErrorInfo contains pointers to static storage */
+        /**/
+        memset(&r->error, 0, sizeof(r->error));
     }
-    else
-    {
-        RewritePointersRuntimeLoad(r, base);
-    }
+    // REWRITE_F(IM3Environment, r->environment, base, is_store,
+    //     RewritePointersEnvironment);
+    do {
+        if (is_store)
+        {
+            IM3Environment off = TO_OFF(IM3Environment, r->environment, base);
+            if (off != (r->environment))
+            {
+                IM3Environment ptr_tmp = r->environment;
+                r->environment = off;
+                RewritePointersEnvironment(ptr_tmp, base, is_store);
+            }
+        }
+        else
+        {
+            IM3Environment ptr = NULL;
+            ptr = TO_PTR(IM3Environment, r->environment, base);
+            if (ptr != (r->environment))
+            {
+                r->environment = ptr;
+                RewritePointersEnvironment(ptr, base, is_store);
+            }
+        }
+    } while (0);
+    /* Code pages are allocated transiently */
+    NULLIFY_STORE(r->pagesOpen, is_store);
+    NULLIFY_STORE(r->pagesFull, is_store);
+    REWRITE_F(IM3Module, r->modules, base, is_store,
+        RewritePointersModule);
+    REWRITE(void*, r->stack, base, is_store);
+    REWRITE(m3slot_t*, r->stack_suspend, base, is_store);
+    NULLIFY_STORE(r->base, is_store);
+    NULLIFY_STORE(r->base_transient, is_store);
+    /* don't enter runtime->lastCalled, we will get there eventually */
+    REWRITE(IM3Function, r->lastCalled, base, is_store);
+    /* user is responsible for his data */
+    NULLIFY_STORE(r->userdata, is_store);
+    NULLIFY_STORE(r->userdata_import, is_store);
+    RewritePointersMemory(&r->memory, base, is_store);
 }

--- a/source/m3_rewrite.c
+++ b/source/m3_rewrite.c
@@ -1,0 +1,213 @@
+#include "m3_env.h"
+
+#include "m3_rewrite.h"
+
+// base pointer must be 16 byte alligned
+
+#if (d_m3EnableCodePageRefCounting)
+#   define nullify_codepagerefs NULLIFY_STORE(f->codePageRefs, IS_STORE)
+#else
+#   define nullify_codepagerefs do {} while (0)
+#endif
+
+#define RewritePointersFunction(STORE_OR_LOAD, IS_STORE)                        \
+    static void                                                                 \
+    RewritePointersFunction##STORE_OR_LOAD(IM3Function f, u8* base)             \
+    {                                                                           \
+        REWRITE(IM3Module, f->module, base, IS_STORE);                          \
+        REWRITE(char*, f->import.moduleUtf8, base, IS_STORE);                   \
+        REWRITE(char*, f->import.fieldUtf8, base, IS_STORE);                    \
+        REWRITE(bytes_t, f->wasm, base, IS_STORE);                              \
+        REWRITE(bytes_t, f->wasmEnd, base, IS_STORE);                           \
+        for (u32 i = 0; i < f->numNames; i++)                                   \
+        {                                                                       \
+            REWRITE(cstr_t, f->names[i], base, IS_STORE);                       \
+        }                                                                       \
+        REWRITE(cstr_t*, f->names, base, IS_STORE);                             \
+        REWRITE(IM3FuncType, f->funcType, base, IS_STORE);                      \
+        NULLIFY_STORE(f->compiled, IS_STORE);                                   \
+        nullify_codepagerefs;                                                   \
+        REWRITE(void*, f->constants, base, IS_STORE);                           \
+    }
+RewritePointersFunction(Store, 1)
+RewritePointersFunction(Load, 0)
+
+
+#define RewritePointersDataSegment(STORE_OR_LOAD, IS_STORE)                     \
+    static void                                                                 \
+    RewritePointersDataSegment##STORE_OR_LOAD(M3DataSegment* d, u8* base)       \
+    {                                                                           \
+        REWRITE(u8*, d->initExpr, base, IS_STORE);                              \
+        REWRITE(u8*, d->data, base, IS_STORE);                                  \
+    }
+RewritePointersDataSegment(Store, 1)
+RewritePointersDataSegment(Load, 0)
+
+
+#define RewritePointersGlobal(STORE_OR_LOAD, IS_STORE)                          \
+    static void                                                                 \
+    RewritePointersGlobal##STORE_OR_LOAD(IM3Global g, u8* base)                 \
+    {                                                                           \
+        REWRITE(char*, g->import.fieldUtf8, base, IS_STORE);                    \
+        REWRITE(char*, g->import.moduleUtf8, base, IS_STORE);                   \
+        REWRITE(cstr_t, g->name, base, IS_STORE);                               \
+        REWRITE(bytes_t, g->initExpr, base, IS_STORE);                          \
+    }
+RewritePointersGlobal(Store, 1)
+RewritePointersGlobal(Load, 0)
+
+
+
+#define RewritePointersFuncType(STORE_OR_LOAD, IS_STORE)                        \
+    static void                                                                 \
+    RewritePointersFuncType##STORE_OR_LOAD(IM3FuncType t, u8* base)             \
+    {                                                                           \
+        REWRITE_F(IM3FuncType,                                                  \
+            t->next,                                                            \
+            base,                                                               \
+            IS_STORE,                                                           \
+            RewritePointersFuncType##STORE_OR_LOAD);                            \
+    }
+RewritePointersFuncType(Store, 1)
+RewritePointersFuncType(Load, 0)
+
+
+#define RewritePointersMemoryHeader(STORE_OR_LOAD, IS_STORE)                    \
+    static void                                                                 \
+    RewritePointersMemoryHeader##STORE_OR_LOAD(M3MemoryHeader* h, u8* base)     \
+    {                                                                           \
+        REWRITE(IM3Runtime, h->runtime, base, IS_STORE);                        \
+        REWRITE(void*, h->maxStack, base, IS_STORE);                            \
+    }
+RewritePointersMemoryHeader(Store, 1)
+RewritePointersMemoryHeader(Load, 0)
+
+
+#define RewritePointersMemory(STORE_OR_LOAD, IS_STORE)                          \
+    static void                                                                 \
+    RewritePointersMemory##STORE_OR_LOAD(M3Memory* m, u8* base)                 \
+    {                                                                           \
+        REWRITE_F(M3MemoryHeader *, m->mallocated, base, IS_STORE,              \
+            RewritePointersMemoryHeader##STORE_OR_LOAD);                        \
+    }
+RewritePointersMemory(Store, 1)
+RewritePointersMemory(Load, 0)
+
+
+#define RewritePointersModule(STORE_OR_LOAD, IS_STORE)                          \
+    static void                                                                 \
+    RewritePointersModule##STORE_OR_LOAD(IM3Module m, u8* base)                 \
+    {                                                                           \
+        /* do not enter runtime, environment, they called us */                 \
+        REWRITE(IM3Runtime, m->runtime, base, IS_STORE);                        \
+        REWRITE(IM3Environment, m->environment, base, IS_STORE);                \
+        REWRITE(bytes_t, m->wasmStart, base, IS_STORE);                         \
+        REWRITE(bytes_t, m->wasmEnd, base, IS_STORE);                           \
+        REWRITE(cstr_t, m->name, base, IS_STORE);                               \
+        for (u32 i = 0; i < m->numFuncTypes; i++)                               \
+        {                                                                       \
+            /* do not enter funcTypes, they are handled in environment */       \
+            REWRITE(IM3FuncType, m->funcTypes[i], base, IS_STORE);              \
+        }                                                                       \
+        REWRITE(IM3FuncType*, m->funcTypes, base, IS_STORE);                    \
+        for (u32 i = 0; i < m->numFunctions; i++)                               \
+        {                                                                       \
+            RewritePointersFunction##STORE_OR_LOAD(&m->functions[i],base);      \
+        }                                                                       \
+        REWRITE(M3Function *, m->functions, base, IS_STORE);                    \
+        for (u32 i = 0; i < m->numDataSegments; i++)                            \
+        {                                                                       \
+            RewritePointersDataSegment##STORE_OR_LOAD(                          \
+                &m->dataSegments[i],                                            \
+                base                                                            \
+            );                                                                  \
+        }                                                                       \
+        REWRITE(M3DataSegment *, m->dataSegments, base, IS_STORE);              \
+        for (u32 i = 0; i < m->numGlobals; i++)                                 \
+        {                                                                       \
+            RewritePointersGlobal##STORE_OR_LOAD(&m->globals[i], base);         \
+        }                                                                       \
+        REWRITE(M3Global *, m->globals, base, IS_STORE);                        \
+        REWRITE(bytes_t, m->elementSection, base, IS_STORE);                    \
+        REWRITE(bytes_t, m->elementSectionEnd, base, IS_STORE);                 \
+        for (u32 i = 0; i < m->table0Size; i++)                                 \
+        {                                                                       \
+            REWRITE(IM3Function, m->table0[i], base, IS_STORE);                 \
+        }                                                                       \
+        REWRITE(IM3Function*, m->table0, base, IS_STORE);                       \
+        REWRITE_F(IM3Module,                                                    \
+            m->next,                                                            \
+            base,                                                               \
+            IS_STORE,                                                           \
+            RewritePointersModule##STORE_OR_LOAD);                              \
+    }
+RewritePointersModule(Store, 1)
+RewritePointersModule(Load, 0)
+
+
+#define RewritePointersEnvironment(STORE_OR_LOAD, IS_STORE)                     \
+    static void                                                                 \
+    RewritePointersEnvironment##STORE_OR_LOAD(IM3Environment e, u8* base)       \
+    {                                                                           \
+        REWRITE_F(IM3FuncType, e->funcTypes, base, IS_STORE,                    \
+            RewritePointersFuncType##STORE_OR_LOAD);                            \
+        for (u32 i = 0; i < c_m3Type_unknown; i++)                              \
+        {                                                                       \
+            /* retFuncTypes "point" to funcTypes, do not enter */               \
+            REWRITE(IM3FuncType, e->retFuncTypes[i], base, IS_STORE);           \
+        }                                                                       \
+            NULLIFY_STORE(e->pagesReleased, IS_STORE);                          \
+    }
+RewritePointersEnvironment(Store, 1)
+RewritePointersEnvironment(Load, 0)
+
+
+#define RewritePointersRuntime(STORE_OR_LOAD, IS_STORE)                         \
+    static void                                                                 \
+    RewritePointersRuntime##STORE_OR_LOAD(IM3Runtime r, u8* base)               \
+    {                                                                           \
+        if (IS_STORE)                                                           \
+        {                                                                       \
+            /* reset compilation, code pages must be freed           */         \
+            /* this is because code pages contain function pointers, */         \
+            /* and preserving them does not seem feasible            */         \
+            /**/                                                                \
+            memset(&r->compilation, 0, sizeof(r->compilation));                 \
+            /* ErrorInfo contains pointers to static storage */                 \
+            /**/                                                                \
+            memset(&r->error, 0, sizeof(r->error));                             \
+        }                                                                       \
+        REWRITE_F(IM3Environment, r->environment, base, IS_STORE,               \
+            RewritePointersEnvironment##STORE_OR_LOAD);                         \
+        /* Code pages are allocated transiently */                              \
+        NULLIFY_STORE(r->pagesOpen, IS_STORE);                                  \
+        NULLIFY_STORE(r->pagesFull, IS_STORE);                                  \
+        REWRITE_F(IM3Module, r->modules, base, IS_STORE,                        \
+            RewritePointersModule##STORE_OR_LOAD);                              \
+        REWRITE(void*, r->stack, base, IS_STORE);                               \
+        REWRITE(m3slot_t*, r->stack_suspend, base, IS_STORE);                   \
+        NULLIFY_STORE(r->base, IS_STORE);                                       \
+        NULLIFY_STORE(r->base_transient, IS_STORE);                             \
+        /* don't enter runtime->lastCalled, we will get there eventually */     \
+        REWRITE(IM3Function, r->lastCalled, base, IS_STORE);                    \
+        /* user is responsible for his data */                                  \
+        NULLIFY_STORE(r->userdata, IS_STORE);                                   \
+        NULLIFY_STORE(r->userdata_import, IS_STORE);                            \
+        RewritePointersMemory##STORE_OR_LOAD(&r->memory, base);                 \
+    }
+RewritePointersRuntime(Store, 1)
+RewritePointersRuntime(Load, 0)
+
+
+void
+m3_RewritePointersRuntime(IM3Runtime r, u8* base, bool is_store)
+{
+    if (is_store)
+    {
+        RewritePointersRuntimeStore(r, base);
+    }
+    else
+    {
+        RewritePointersRuntimeLoad(r, base);
+    }
+}

--- a/source/m3_rewrite.h
+++ b/source/m3_rewrite.h
@@ -1,5 +1,5 @@
-#ifndef m3_validate_h
-#define m3_validate_h
+#ifndef m3_rewrite_h
+#define m3_rewrite_h
 
 #include "wasm3.h"
 #include "m3_core.h"
@@ -42,7 +42,7 @@
             {                                       \
                 TYPE ptr_tmp = PTR;                 \
                 PTR = off;                          \
-                FUNC(ptr_tmp, BASE);                \
+                FUNC(ptr_tmp, BASE, IS_STORE);      \
             }                                       \
         }                                           \
         else                                        \
@@ -51,7 +51,7 @@
             if (ptr != (PTR))                       \
             {                                       \
                 PTR = ptr;                          \
-                FUNC(ptr, BASE);                    \
+                FUNC(ptr, BASE, IS_STORE);          \
             }                                       \
         }                                           \
     } while (0)
@@ -66,4 +66,4 @@
 
 void m3_RewritePointersRuntime(IM3Runtime runtime, u8* base, bool is_subtract);
 
-#endif // m3_validate_h
+#endif // m3_rewrite_h

--- a/source/m3_rewrite.h
+++ b/source/m3_rewrite.h
@@ -1,0 +1,69 @@
+#ifndef m3_validate_h
+#define m3_validate_h
+
+#include "wasm3.h"
+#include "m3_core.h"
+
+
+// offsets encoded as pointers have their top bit set
+
+#if __SIZEOF_POINTER__ != 8
+    #error "todo portable macros"
+#endif
+
+#define TO_OFF(TYPE, PTR, BASE)                                                 \
+    ( (!(PTR) || ((uintptr_t)(PTR) & (1ULL << 63)))                             \
+        ? (PTR)                                                                 \
+        : (TYPE)(((u8*)(PTR) - (u8*)(BASE)) + (u8*)((uintptr_t)1ULL << 63)) )
+
+#define TO_PTR(TYPE, PTR, BASE)                                                 \
+    ( (!(PTR) || !((uintptr_t)(PTR) & (1ULL << 63)))                            \
+        ? (PTR)                                                                 \
+        : (TYPE)(((u8*)(PTR) - (u8*)((uintptr_t)1ULL << 63)) + (u8*)(BASE)) )
+
+#define REWRITE(TYPE, PTR, BASE, IS_STORE)  \
+    do {                                    \
+        if (IS_STORE)                       \
+        {                                   \
+            PTR = TO_OFF(TYPE, PTR, BASE);  \
+        }                                   \
+        else                                \
+        {                                   \
+            PTR = TO_PTR(TYPE, PTR, BASE);  \
+        }                                   \
+    } while (0)
+
+#define REWRITE_F(TYPE, PTR, BASE, IS_STORE, FUNC)  \
+    do {                                            \
+        if (IS_STORE)                               \
+        {                                           \
+            TYPE off = TO_OFF(TYPE, PTR, BASE);     \
+            if (off != (PTR))                       \
+            {                                       \
+                TYPE ptr_tmp = PTR;                 \
+                PTR = off;                          \
+                FUNC(ptr_tmp, BASE);                \
+            }                                       \
+        }                                           \
+        else                                        \
+        {                                           \
+            TYPE ptr = TO_PTR(TYPE, PTR, BASE);     \
+            if (ptr != (PTR))                       \
+            {                                       \
+                PTR = ptr;                          \
+                FUNC(ptr, BASE);                    \
+            }                                       \
+        }                                           \
+    } while (0)
+
+#define NULLIFY_STORE(PTR, IS_STORE)                \
+    do {                                            \
+        if (IS_STORE)                               \
+        {                                           \
+            (PTR) = NULL;                           \
+        }                                           \
+    } while (0)
+
+void m3_RewritePointersRuntime(IM3Runtime runtime, u8* base, bool is_subtract);
+
+#endif // m3_validate_h

--- a/source/m3_rewrite.h
+++ b/source/m3_rewrite.h
@@ -5,7 +5,8 @@
 #include "m3_core.h"
 
 
-// offsets encoded as pointers have their top bit set
+// offsets encoded as pointers have their top bit set to 1
+// base ptr must be 16 byte aligned
 
 #if __SIZEOF_POINTER__ != 8
     #error "todo portable macros"

--- a/source/m3_rewrite.h
+++ b/source/m3_rewrite.h
@@ -15,12 +15,12 @@
 #define TO_OFF(TYPE, PTR, BASE)                                                 \
     ( (!(PTR) || ((uintptr_t)(PTR) & (1ULL << 63)))                             \
         ? (PTR)                                                                 \
-        : (TYPE)(((u8*)(PTR) - (u8*)(BASE)) + (u8*)((uintptr_t)1ULL << 63)) )
+        : (TYPE)(((u8*)(PTR) - (u8*)(BASE)) + (u8*)((uintptr_t)(1ULL << 63))) )
 
 #define TO_PTR(TYPE, PTR, BASE)                                                 \
     ( (!(PTR) || !((uintptr_t)(PTR) & (1ULL << 63)))                            \
         ? (PTR)                                                                 \
-        : (TYPE)(((u8*)(PTR) - (u8*)((uintptr_t)1ULL << 63)) + (u8*)(BASE)) )
+        : (TYPE)(((u8*)(PTR) - (u8*)((uintptr_t)(1ULL << 63))) + (u8*)(BASE)) )
 
 #define REWRITE(TYPE, PTR, BASE, IS_STORE)  \
     do {                                    \

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -185,6 +185,10 @@ d_m3ErrorConst  (trapAbort,                     "[trap] program called abort")
 d_m3ErrorConst  (trapUnreachable,               "[trap] unreachable executed")
 d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 
+// misc results
+d_m3ErrorConst  (NoSuspensionStack,             "no suspension stack")
+d_m3ErrorConst  (ComputationBlock,              "wasm3 encountered a blocking computation and might perform suspension")
+
 
 //-------------------------------------------------------------------------------------------------------------------------------
 //  configuration, can be found in m3_config.h, m3_config_platforms.h, m3_core.h)
@@ -203,7 +207,8 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 
     IM3Runtime          m3_NewRuntime               (IM3Environment         io_environment,
                                                      uint32_t               i_stackSizeInBytes,
-                                                     void *                 i_userdata);
+                                                     void *                 i_userdata,
+                                                     bool                   suspend);
 
     void                m3_FreeRuntime              (IM3Runtime             i_runtime);
 

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -231,9 +231,15 @@ d_m3ErrorConst  (SuspensionError,               "error during suspension")
                                                      void  (* free_fn)(void*),
                                                      void* (* realloc_fn)(void*, size_t));
                                                     
-    M3Result            m3_SetMemoryAllocators   (void* (* calloc_fn)(size_t, size_t),
+    M3Result            m3_SetMemoryAllocators      (void* (* calloc_fn)(size_t, size_t),
                                                      void  (* free_fn)(void*),
                                                      void* (* realloc_fn)(void*, size_t));
+
+    void                m3_RewritePointersRuntime   (IM3Runtime runtime,
+                                                     uint8_t* base,
+                                                     bool is_subtract);
+
+    M3Result            m3_Resume                   (IM3Runtime runtime);
 
 
 //-------------------------------------------------------------------------------------------------------------------------------
@@ -281,6 +287,7 @@ d_m3ErrorConst  (SuspensionError,               "error during suspension")
     const char*         m3_GetModuleName            (IM3Module i_module);
     void                m3_SetModuleName            (IM3Module i_module, const char* name);
     IM3Runtime          m3_GetModuleRuntime         (IM3Module i_module);
+    M3Result            m3_ValidateModule           (IM3Module i_module);
 
 //-------------------------------------------------------------------------------------------------------------------------------
 //  globals

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -230,6 +230,10 @@ d_m3ErrorConst  (SuspensionError,               "error during suspension")
     M3Result            m3_SetTransientAllocators   (void* (* calloc_fn)(size_t, size_t),
                                                      void  (* free_fn)(void*),
                                                      void* (* realloc_fn)(void*, size_t));
+                                                    
+    M3Result            m3_SetMemoryAllocators   (void* (* calloc_fn)(size_t, size_t),
+                                                     void  (* free_fn)(void*),
+                                                     void* (* realloc_fn)(void*, size_t));
 
 
 //-------------------------------------------------------------------------------------------------------------------------------

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -221,6 +221,10 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
                                                      void  (* free_fn)(void*),
                                                      void* (* realloc_fn)(void*, size_t));
 
+    M3Result            m3_SetTransientAllocators   (void* (* calloc_fn)(size_t, size_t),
+                                                     void  (* free_fn)(void*),
+                                                     void* (* realloc_fn)(void*, size_t));
+
 
 //-------------------------------------------------------------------------------------------------------------------------------
 //  modules

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -188,6 +188,7 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 // misc results
 d_m3ErrorConst  (NoSuspensionStack,             "no suspension stack")
 d_m3ErrorConst  (ComputationBlock,              "wasm3 encountered a blocking computation and might perform suspension")
+d_m3ErrorConst  (SuspensionError,               "error during suspension")
 
 
 //-------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Adds two more sets of allocation functions to allocate code pages and linear memory buffer separately;
- Adds a suspension stack: a callstack for operators/function calls in wasm3 and function calls in the hosting environment;
- Adds resume routine to resolve suspended/blocked computation;
- Adds pointer rewrite routine for m3 structs to allow persistent storage of the suspended module state