### PR TITLE
polling, stashing/restoration of globals

### DIFF
--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -273,6 +273,39 @@ void *  m3_CopyMemTransient  (const void * i_from, size_t i_size)
 
 //--------------------------------------------------------------------------------------------
 
+static void(* m3_poller )(void);
+
+void m3_SetPoller (void(*callback_fn)(void))
+{
+    m3_poller = callback_fn;
+}
+
+void m3_Poll(void)
+{
+    if (m3_poller) m3_poller();
+}
+
+//--------------------------------------------------------------------------------------------
+
+
+void m3_StashSettable(M3GlobalSettable* stash)
+{
+    stash->allocators.module = m3_alloc_funcs;
+    stash->allocators.transient = m3_alloc_transient_funcs;
+    stash->allocators.memory = m3_alloc_memory_funcs;
+    stash->poll_fn = m3_poller;
+}
+
+void m3_RestoreSettable(M3GlobalSettable* stash)
+{
+    m3_alloc_funcs = stash->allocators.module;
+    m3_alloc_transient_funcs = stash->allocators.transient;
+    m3_alloc_memory_funcs = stash->allocators.memory;
+    m3_poller = stash->poll_fn;
+}
+
+//--------------------------------------------------------------------------------------------
+
 #if d_m3LogNativeStack
 
 static size_t stack_start;

--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -162,6 +162,17 @@ typedef struct M3AllocationFunctionStruct
 }
 M3AllocationFunctionStruct;
 
+typedef struct M3GlobalSettable
+{
+    struct {
+        M3AllocationFunctionStruct module;
+        M3AllocationFunctionStruct transient;
+        M3AllocationFunctionStruct memory;
+    } allocators;
+    
+    void(* poll_fn )(void);
+} M3GlobalSettable;
+
 #define d_m3CodePageFreeLinesThreshold      4+2       // max is: select _sss & CallIndirect + 2 for bridge
 
 #define d_m3MemPageSize                     65536
@@ -236,6 +247,12 @@ void *      m3_MallocMemory         (size_t i_size);
 void *      m3_ReallocMemory        (void *i_ptr, size_t i_newSize, size_t i_oldSize);
 void        m3_FreeMemoryImpl       (void * i_ptr);
 void *      m3_CopyMemTransient     (const void * i_from, size_t i_size);
+
+void        m3_SetPoller            (void(*callback_fn)(void));
+void        m3_Poll                 (void);
+
+void        m3_StashSettable        (struct M3GlobalSettable* stash);
+void        m3_RestoreSettable      (struct M3GlobalSettable* stash);
 
 #define     m3_AllocStruct(STRUCT)                  (STRUCT *)m3_Malloc (sizeof (STRUCT))
 #define     m3_AllocArray(STRUCT, NUM)              (STRUCT *)m3_Malloc (sizeof (STRUCT) * (NUM))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -604,6 +604,8 @@ d_m3Op  (SetGlobal_i64)
 
 d_m3Op  (Call)
 {
+    m3_Poll();
+
     pc_t callPC                 = immediate (pc_t);
     i32 stackOffset             = immediate (i32);
     IM3Memory memory            = m3MemInfo (_mem);
@@ -654,6 +656,8 @@ d_m3Op  (Call)
 
 d_m3Op  (CallIndirect)
 {
+    m3_Poll();
+
     u32 tableIndex              = slot (u32);
     IM3Module module            = immediate (IM3Module);
     IM3FuncType type            = immediate (IM3FuncType);
@@ -730,6 +734,8 @@ d_m3Op  (CallIndirect)
 
 d_m3Op  (CallRawFunction)
 {
+    m3_Poll();
+    
     d_m3TracePrepare
 
     M3ImportContext ctx;
@@ -1363,6 +1369,7 @@ d_m3Op  (ContinueLoop)
     // TODO: this is where execution can "escape" the M3 code and callback to the client / fiber switch
     // OR it can go in the Loop operation. I think it's best to do here. adding code to the loop operation
     // has the potential to increase its native-stack usage. (don't forget ContinueLoopIf too.)
+    m3_Poll();
 
     void * loopId = immediate (void *);
     return loopId;
@@ -1376,6 +1383,7 @@ d_m3Op  (ContinueLoopIf)
 
     if (condition)
     {
+        m3_Poll();
         return loopId;
     }
     else nextOp ();


### PR DESCRIPTION
Added another global `m3_poller` for an optional callback that gets called in Wasm loops and before function calls. It won't be used in Vere now but it might get used in the future.

Also adds struct definition and a function to stash/restore global variables that wasm3 uses.